### PR TITLE
Add new command "console" to entrypoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ openhab:
 ```
 then start with ``docker-compose up -d``
 
+**Accessing the console**
+``docker exec -it openhab console``
+
 **Debug Mode**
 
 You can start the container with the command ``docker run -it openhab/openhab debug`` to get into the debug shell.

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -20,6 +20,8 @@ if [ "$1" = 'server' ] || [ "$1" = 'openhab' ]; then
   eval "${APPDIR}/start.sh"
 elif [ "$1" = 'debug' ]; then
   eval "${APPDIR}/start_debug.sh"
+elif [ "$1" = 'console' ] || [ "$1" = 'shell' ]; then
+  exec "${APPDIR}/runtime/karaf/bin/client"
 else
   exec "$@"
 fi


### PR DESCRIPTION
Hi!

I thought it might be interesting to access the console even when running the container as daemon in the background.
As the configuration is in the runtime folderfor now, I expect that there will be changes in the future how password and ssh-keys are going to be handled.

Cheers
Hannes