### PR TITLE
[WIP] use gosu instead of sudo

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -6,23 +6,23 @@ IFS=$'\n\t'
 if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
   # Copy userdata dir
   echo "No userdata found... initializing."
-  sudo cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
+  cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
 fi
 
 if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
   # Copy userdata dir
   echo "No configuration found... initializing."
-  sudo cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+  cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
 fi
 
 # Prettier interface
 if [ "$1" = 'server' ] || [ "$1" = 'openhab' ]; then
-  eval "${APPDIR}/start.sh"
+  gosu openhab "${APPDIR}/start.sh"
 elif [ "$1" = 'debug' ]; then
-  eval "${APPDIR}/start_debug.sh"
+  gosu openhab "${APPDIR}/start_debug.sh"
 elif [ "$1" = 'console' ] || [ "$1" = 'shell' ]; then
-  exec "${APPDIR}/runtime/karaf/bin/client"
+  gosu openhab "${APPDIR}/runtime/karaf/bin/client"
 else
-  exec "$@"
+  gosu openhab "$@"
 fi
 


### PR DESCRIPTION
Hello!

According to the [Dockerfile Best Practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#user) one should use gosu instead of sudo to circumvent problems arising with apparmor on the host system.
I prepared a test image on dockerhub for x86: ``docker pull cyberkov/openhab2:gosu`` to try it out.
Unfortunately I cannot reproduce the problem on Debian Jessie yet, so I would be glad if someone could verify it.
This should fix #12 

Cheers
Hannes