### PR TITLE
[WIP] use gosu instead of sudo

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -6,23 +6,23 @@ IFS=$'\n\t'
 if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
   # Copy userdata dir
   echo "No userdata found... initializing."
-  sudo cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
+  cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
 fi
 
 if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
   # Copy userdata dir
   echo "No configuration found... initializing."
-  sudo cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+  cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
 fi
 
 # Prettier interface
 if [ "$1" = 'server' ] || [ "$1" = 'openhab' ]; then
-  eval "${APPDIR}/start.sh"
+  gosu openhab "${APPDIR}/start.sh"
 elif [ "$1" = 'debug' ]; then
-  eval "${APPDIR}/start_debug.sh"
+  gosu openhab "${APPDIR}/start_debug.sh"
 elif [ "$1" = 'console' ] || [ "$1" = 'shell' ]; then
-  exec "${APPDIR}/runtime/bin/client"
+  gosu openhab "${APPDIR}/runtime/bin/client"
 else
-  exec "$@"
+  gosu openhab "$@"
 fi
 


### PR DESCRIPTION
This should fix [#12](https://github.com/openhab/openhab-docker/issues/12). This is a new pull request instead of [#13](https://github.com/openhab/openhab-docker/pull/13). I merged the changes and tested them on Debian jessie with following docker compose file:

```
openhab2:
  image: "openhab/usegosu"
  net: host
  volumes:
    - "/etc/localtime:/etc/localtime:ro"
    - "/etc/timezone:/etc/timezone:ro"
    - "/opt/usegosu/userdata:/openhab/userdata"
    - "/opt/usegosu/conf:/openhab/conf"
  command: "server"
```

Signed-off-by: Christian Lehmann info@legacycode.org (github: legacycode)