### PR TITLE
fixed broken build for arm64. migrated from ubuntu to debian jessie. …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,9 @@ env:
   # -  DOCKER_USERNAME
   # -  DOCKER_PASSWORD
   matrix:
-    - TARGET=amd64 FLAVOR=online
-    - TARGET=amd64 FLAVOR=offline
-    - TARGET=armhf FLAVOR=online
-    - TARGET=armhf FLAVOR=offline
-    - TARGET=arm64 FLAVOR=online
-    - TARGET=arm64 FLAVOR=offline
+    - TARGET=amd64
+    - TARGET=armhf
+    - TARGET=arm64
 matrix:
   fast_finish: true
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # openhab image 
-FROM multiarch/ubuntu-debootstrap:amd64-wily
-#FROM multiarch/ubuntu-debootstrap:armhf-wily   # arch=armhf
-#FROM multiarch/ubuntu-debootstrap:arm64-wily   # arch=arm64
+FROM multiarch/debian-debootstrap:amd64-jessie  # arch=amd64
+#FROM multiarch/debian-debootstrap:armhf-jessie  # arch=armhf
+#FROM multiarch/debian-debootstrap:arm64-jessie  # arch=arm64
 ARG ARCH=amd64
 
 ARG DOWNLOAD_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.0.0-SNAPSHOT.zip"
@@ -19,11 +19,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/openhab/openhab-docker.git"
 
-# Install Basepackages
+# Install Basepackages & OpenJDK8
 RUN \
+    echo deb http://http.debian.net/debian jessie-backports main >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-      software-properties-common \
+      openjdk-8-jdk \
       unzip \
       wget \
     && rm -rf /var/lib/apt/lists/*
@@ -39,16 +40,6 @@ RUN set -x \
     && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true
-
-# Install Oracle Java
-RUN \
-  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-  add-apt-repository -y ppa:webupd8team/java && \
-  apt-get update && \
-  apt-get install --no-install-recommends -y oracle-java8-installer && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /var/cache/oracle-jdk8-installer
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,13 @@ BASE_ARCH ?= amd64
 DOCKER_REPO ?= openhab/openhab
 TRAVIS_GIT_REPO ?= openhab/openhab-docker
 TRAVIS_GIT_BRANCH ?= master
-FLAVOR ?= online
 TRAVIS_TOKEN ?= secretsecret
 
-ifeq ($(FLAVOR),offline)
-  DOWNLOAD_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.0.0-SNAPSHOT.zip"
-else
-  DOWNLOAD_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.0.0-SNAPSHOT.zip"
-endif
+DOWNLOAD_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.0.0-SNAPSHOT.zip"
 
 build: tmp-$(TARGET)/Dockerfile
-	docker build --build-arg ARCH=$(TARGET) --build-arg DOWNLOAD_URL=$(DOWNLOAD_URL) --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $(DOCKER_REPO):$(TARGET)-$(FLAVOR) tmp-$(TARGET)
-	docker run --rm $(DOCKER_REPO):$(TARGET)-$(FLAVOR) uname -a
+	docker build --build-arg ARCH=$(TARGET) --build-arg DOWNLOAD_URL=$(DOWNLOAD_URL) --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $(DOCKER_REPO):$(TARGET) tmp-$(TARGET)
+	docker run --rm $(DOCKER_REPO):$(TARGET) uname -a
 
 tmp-$(TARGET)/Dockerfile: Dockerfile $(shell find files)
 	rm -rf tmp-$(TARGET)
@@ -32,7 +27,7 @@ tmp-$(TARGET)/Dockerfile: Dockerfile $(shell find files)
 	cat $@
 
 test:
-	env IMAGE="$(DOCKER_REPO):$(TARGET)-$(FLAVOR)" \
+	env IMAGE="$(DOCKER_REPO):$(TARGET)" \
 	bundle exec rspec
 
 clean:
@@ -41,7 +36,7 @@ clean:
 	done
 
 push:
-	docker push $(DOCKER_REPO):$(TARGET)-$(FLAVOR)
+	docker push $(DOCKER_REPO):$(TARGET)
 
 trigger:
 	@curl -s -X POST \

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ When not explicitly set, files are placed under [![Eclipse license](https://img.
 
 ## Image Variants
 
-### ``openhab/openhab:<architecture>-<[on|off]line>``
+### ``openhab/openhab:<architecture>``
 
-* ``amd64``: ``online``, ``offline``
-* ``armhf``: ``online``, ``offline``
-* ``arm64``: ``online``, ``offline``
+* ``amd64`` for most desktop computer
+* ``armhf`` for ARMv7 devices 32 Bit (e.g. most RaspberryPi 1/2/3)
+* ``arm64`` for ARMv8 devices 64Bit (not RaspberryPi 3)
 
-If you are unsure about what your needs are, you probably want to use ``openhab/openhab:amd64-online``.
+If you are unsure about what your needs are, you probably want to use ``openhab/openhab:amd64``.
 
 prebuilt Docker Images can be found here: [Docker Images](https://hub.docker.com/r/openhab/openhab)
 
@@ -37,7 +37,7 @@ prebuilt Docker Images can be found here: [Docker Images](https://hub.docker.com
 
 The following will run openHAB in demo mode on the host machine:
 ```
-docker run -it --name openhab --net=host openhab/openhab:amd64-online server
+docker run -it --name openhab --net=host openhab/openhab:amd64 server
 ```
 
 **NOTE** Although this is the simplest method to getting openHAB up and running, but it is not the preferred method. To properly run the container, please specify a **host volume** for the ``conf`` and ``userdata`` directory:
@@ -53,35 +53,35 @@ docker run \
         -v /opt/openhab/userdata:/openhab/userdata \
         -d \
         --restart=always \
-        openhab/openhab:amd64-online
+        openhab/openhab:amd64
 ```
 
-or with ``docker-compose.yml``
+or with ``docker-compose.yml`` and UPnP for discovery:
 ```
----
 openhab:
-  image: 'openhab/openhab:amd64-online'
+  image: "openhab/openhab:amd64"
   restart: always
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "5555:5555"
-  net: "host"
+  net: host
   volumes:
-    - '/etc/localtime:/etc/localtime:ro'
-    - '/etc/timezone:/etc/timezone:ro'
-    - '/opt/openhab/userdata:/openhab/userdata'
-    - '/opt/openhab/conf:/openhab/conf'
-  command: "server"
+    - "/etc/localtime:/etc/localtime:ro"
+    - "/etc/timezone:/etc/timezone:ro"
+    - "/opt/openhab/userdata:/openhab/userdata"
+    - "/opt/openhab/conf:/openhab/conf"
+  environment:
+    OPENHAB_HTTP_PORT: "8080"
+    OPENHAB_HTTPS_PORT: "8443"
+  command: server
 ```
-then start with ``docker-compose up -d``
+Create and start the container with ``docker-compose up -d``
 
 **Accessing the console**
-``docker exec -it openhab /openhab/runtime/bin/client``
+You can connect to a console of an already running openhab container with following command:
+``docker ps``  - lists all your currently running container
+``docker exec -it openhab /openhab/runtime/bin/client`` - connect to given container by name
+``docker exec -it c4ad98f24423 /openhab/runtime/bin/client`` - connect to given container by id
 
 **Debug Mode**
-
-You can start the container with the command ``docker run -it openhab/openhab debug`` to get into the debug shell.
+You can run a new container with the command ``docker run -it openhab/openhab:<architecture> debug`` to get into the debug shell.
 
 **Environment variables**
 *  `OPENHAB_HTTP_PORT`=8080
@@ -89,7 +89,6 @@ You can start the container with the command ``docker run -it openhab/openhab de
 *  `EXTRA_JAVA_OPTS`
 
 **Parameters**
-
 * `-p 8080` - the port of the webinterface
 * `-v /openhab/conf` - openhab configs
 * `-v /openhab/userdata` - openhab userdata directory


### PR DESCRIPTION
fixed broken build for arm64. migrated from ubuntu to debian jessie image. migrated from oraclejdk to openjdk8. You can review the build at: https://travis-ci.org/legacycode/openhab2-docker/builds/191054020

Signed-off-by: Christian Lehmann <info@legacycode.org> (github: legacycode)