### PR TITLE
Install fontconfig for OH2 charts

### DIFF
--- a/1.8.3/amd64/Dockerfile
+++ b/1.8.3/amd64/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/1.8.3/arm64/Dockerfile
+++ b/1.8.3/arm64/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/1.8.3/armhf/Dockerfile
+++ b/1.8.3/armhf/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/2.0.0/amd64/Dockerfile
+++ b/2.0.0/amd64/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/2.0.0/arm64/Dockerfile
+++ b/2.0.0/arm64/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/2.0.0/armhf/Dockerfile
+++ b/2.0.0/armhf/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/2.1.0-snapshot/amd64/Dockerfile
+++ b/2.1.0-snapshot/amd64/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/2.1.0-snapshot/arm64/Dockerfile
+++ b/2.1.0-snapshot/arm64/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/2.1.0-snapshot/armhf/Dockerfile
+++ b/2.1.0-snapshot/armhf/Dockerfile
@@ -39,6 +39,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       ca-certificates \
+      fontconfig \
       locales \
       locales-all \
       libpcap-dev \

--- a/update.sh
+++ b/update.sh
@@ -89,6 +89,7 @@ print_basepackages() {
 	RUN apt-get update && \
 	    apt-get install --no-install-recommends -y \
 	      ca-certificates \
+	      fontconfig \
 	      locales \
 	      locales-all \
 	      libpcap-dev \


### PR DESCRIPTION
For the charting feature, the system, where OH2 is running, needs to
have some fonts installed. The package fontconfig should depend on all
needed packages on all systems (a shared library to access fonts and
some fonts (on debian libfreetype6 e.g.)).

I tested this on a amd64 Ubuntu host, however, it should work on armhf
and arm64 platforms, too.

Fixes #73

Signed-off-by: Florian Schmidt <florian.schmidt.welzow@t-online.de>