### PR TITLE
Openhab GROUP_ID can now be set via variable at container creation time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ You can run a new container with the command ``docker run -it openhab/openhab:2.
 *  `OPENHAB_HTTP_PORT`=8080
 *  `OPENHAB_HTTPS_PORT`=8443
 *  `USER_ID`=9001
+*  `GROUP_ID`=9001
 
-By default the openHAB user in the container is running with:
+Group id will default to the same value as the user id. By default the openHAB user in the container is running with:
 
 * `uid=9001(openhab) gid=9001(openhab) groups=9001(openhab)`
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,13 @@ IFS=$'\n\t'
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  groupadd -g $NEW_GROUP_ID openhab
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home ${APPDIR} openhab &&\
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home ${APPDIR} --gid $NEW_GROUP_ID openhab &&\
     groupadd -g 14 uucp2 &&\
     groupadd -g 16 dialout2 &&\
     groupadd -g 18 dialout3 &&\


### PR DESCRIPTION
The uid and gid may not always be the same value. This patch allows the gid to be specified in the environment variable GROUP_ID. If a gid is not specified, the gid will fallback to being the same value as the uid. 

Signed-off-by: Tim Sedlmeyer <tim@sedlmeyer.org> (github: tssva)