### PR TITLE
Install ttf-dejavu for some basic fonts (needed for charts)

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Deleting instance.properties to avoid karaf PID conflict on restart
+# See: https://github.com/openhab/openhab-docker/issues/99
+rm -f /openhab/runtime/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Deleting instance.properties to avoid karaf PID conflict on restart
+# See: https://github.com/openhab/openhab-docker/issues/99
+rm -f /openhab/runtime/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Deleting instance.properties to avoid karaf PID conflict on restart
+# See: https://github.com/openhab/openhab-docker/issues/99
+rm -f /openhab/runtime/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Deleting instance.properties to avoid karaf PID conflict on restart
+# See: https://github.com/openhab/openhab-docker/issues/99
+rm -f /openhab/runtime/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.2.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.2.0-snapshot/amd64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.2.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.2.0-snapshot/arm64/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.2.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.2.0-snapshot/armhf/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/2.2.0-snapshot/i386/alpine/Dockerfile
+++ b/2.2.0-snapshot/i386/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk update && \
 apk add \
 ca-certificates \
 fontconfig \
+ttf-dejavu \
 libpcap-dev \
 unzip \
 dpkg \

--- a/update.sh
+++ b/update.sh
@@ -141,6 +141,7 @@ print_basepackages_alpine() {
 			apk add \
 				ca-certificates \
 				fontconfig \
+				ttf-dejavu \
 				libpcap-dev \
 				unzip \
 				dpkg \


### PR DESCRIPTION
I've used the alpine image instead of the debian and all charts did
not work anymore. After finding:
https://github.com/docker-library/openjdk/issues/73
and installing the ttf.dejavu package manually, the charts worked again.

This commit adds this package to the alpine base packages which needs to
be installed to get a working OH2 environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/113)
<!-- Reviewable:end -->
