### PR TITLE
Delete different instance.properties path, too

### DIFF
--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.2.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.2.0-snapshot/amd64/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.2.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.2.0-snapshot/arm64/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.2.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.2.0-snapshot/armhf/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/2.2.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.2.0-snapshot/i386/alpine/entrypoint.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
 
+# The instance.properties file in OH2.2-SNAP is installed in the tmp
+# directory
+rm -f /openhab/userdata/tmp/instances/instance.properties
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access

--- a/update.sh
+++ b/update.sh
@@ -338,7 +338,7 @@ do
 					cp entrypoint_alpine.sh $dstFile
 					# remove bug fix for version 2 from entrypoint_alpine.sh
 					if [ "$version" == "1.8.3" ]; then
-						line=$(sed "/rm -f \/openhab\/runtime\/instances\/instance.properties/=; d" entrypoint_alpine.sh)
+						line=$(sed "/rm -f \/openhab\/userdata\/tmp\/instances\/instance.properties/=; d" entrypoint_alpine.sh)
 						sed -i "$((line-3)),${line}"d $dstFile
 					fi
 				else


### PR DESCRIPTION
In my OH2 installation, the instance.properties file is located in
the tmp directory, and not in the runtime directory, that's why the
deletion of the file does not succeed, and restarting the container
does not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/114)
<!-- Reviewable:end -->
