### PR TITLE
Exit container with helpful error message when pseudo tty is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 install:
   - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg VERSION=$VERSION -t $DOCKER_REPO:$VERSION-$TARGET-$DIST $VERSION/$TARGET/$DIST
-  - docker run --rm $DOCKER_REPO:$VERSION-$TARGET-$DIST uname -a
+  - docker run --rm --tty $DOCKER_REPO:$VERSION-$TARGET-$DIST uname -a
 after_success:
   - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
   - docker push $DOCKER_REPO:$VERSION-$TARGET-$DIST

--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/amd64/debian/entrypoint.sh
+++ b/1.8.3/amd64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/arm64/debian/entrypoint.sh
+++ b/1.8.3/arm64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/armhf/debian/entrypoint.sh
+++ b/1.8.3/armhf/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/1.8.3/i386/debian/entrypoint.sh
+++ b/1.8.3/i386/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/amd64/debian/entrypoint.sh
+++ b/2.0.0/amd64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/arm64/debian/entrypoint.sh
+++ b/2.0.0/arm64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/armhf/debian/entrypoint.sh
+++ b/2.0.0/armhf/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.0.0/i386/debian/entrypoint.sh
+++ b/2.0.0/i386/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/amd64/debian/entrypoint.sh
+++ b/2.1.0/amd64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/arm64/debian/entrypoint.sh
+++ b/2.1.0/arm64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/armhf/debian/entrypoint.sh
+++ b/2.1.0/armhf/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.1.0/i386/debian/entrypoint.sh
+++ b/2.1.0/i386/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/amd64/debian/entrypoint.sh
+++ b/2.2.0/amd64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/arm64/debian/entrypoint.sh
+++ b/2.2.0/arm64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/armhf/debian/entrypoint.sh
+++ b/2.2.0/armhf/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.2.0/i386/debian/entrypoint.sh
+++ b/2.2.0/i386/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/amd64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/arm64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/armhf/debian/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/i386/alpine/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/2.3.0-snapshot/i386/debian/entrypoint.sh
+++ b/2.3.0-snapshot/i386/debian/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/entrypoint_debian.sh
+++ b/entrypoint_debian.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -x
+
+# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
+test -t 0
+if [ $? -eq 1 ]; then
+    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
+    exit 1
+fi
+
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/update.sh
+++ b/update.sh
@@ -94,7 +94,7 @@ print_basemetadata() {
 	    LC_ALL=en_US.UTF-8 \
 	    LANG=en_US.UTF-8 \
 	    LANGUAGE=en_US.UTF-8
-	
+
 	# Set arguments on build
 	ARG BUILD_DATE
 	ARG VCS_REF
@@ -304,7 +304,7 @@ do
 		for arch in $arches
 		do
 			file=$version/$arch/$base/Dockerfile
-				mkdir -p `dirname $file` 2>/dev/null
+				mkdir -p $(dirname $file) 2>/dev/null
 				echo -n "Writing $file..."
 				print_header $file;
 				print_baseimage $file;
@@ -344,3 +344,4 @@ do
 		done
 	done
 done
+


### PR DESCRIPTION
Fixes #139 and #140

Successfully tested this with debian and alpine on amd64.

I've also converted the Windows line endings to Unix line endings in update.sh otherwise the script would not run on Ubuntu.

Can you please review this @cniweb, @smerschjohann or @martinvw?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/141)
<!-- Reviewable:end -->
