### PR TITLE
Updated arm64 Dockerfile

### DIFF
--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -44,7 +44,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    fontconfig \
     locales \
     locales-all \
     libpcap-dev \
@@ -84,6 +83,7 @@ RUN set -x \
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
+    fontconfig:armhf \
     libc6:armhf && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -44,7 +44,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    fontconfig \
     locales \
     locales-all \
     libpcap-dev \
@@ -84,6 +83,7 @@ RUN set -x \
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
+    fontconfig:armhf \
     libc6:armhf && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -44,7 +44,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    fontconfig \
     locales \
     locales-all \
     libpcap-dev \
@@ -84,6 +83,7 @@ RUN set -x \
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
+    fontconfig:armhf \
     libc6:armhf && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.3.0-snapshot/arm64/debian/Dockerfile
+++ b/2.3.0-snapshot/arm64/debian/Dockerfile
@@ -44,7 +44,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    fontconfig \
     locales \
     locales-all \
     libpcap-dev \
@@ -84,6 +83,7 @@ RUN set -x \
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
+    fontconfig:armhf \
     libc6:armhf && \
     rm -rf /var/lib/apt/lists/*
 

--- a/update.sh
+++ b/update.sh
@@ -124,7 +124,6 @@ print_basepackages() {
 	RUN apt-get update && \
 	    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
 	    ca-certificates \
-	    fontconfig \
 	    locales \
 	    locales-all \
 	    libpcap-dev \
@@ -170,6 +169,7 @@ print_lib32_support_arm64() {
 	RUN dpkg --add-architecture armhf && \
 	    apt-get update && \
 	    apt-get install --no-install-recommends -y \
+		fontconfig:armhf \ 
 	    libc6:armhf && \
 	    rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
 changed installed fontconfig (fontconfig:arm64) to fontconfig:armhf to fix not working charts
 (issue https://github.com/openhab/openhab-docker/issues/152 )

Signed-off-by: Oliver Faßbender <olli@intrepid.de> (github: FoxRomeo)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/153)
<!-- Reviewable:end -->
