### PR TITLE
Make Java cryptographic strength configurable

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \

--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -10,13 +10,21 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Add openhab user & handle possible device groups for different host systems

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/1.8.3/amd64/debian/entrypoint.sh
+++ b/1.8.3/amd64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -10,13 +10,21 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Add openhab user & handle possible device groups for different host systems

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/1.8.3/arm64/debian/entrypoint.sh
+++ b/1.8.3/arm64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -10,13 +10,21 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Add openhab user & handle possible device groups for different host systems

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/1.8.3/armhf/debian/entrypoint.sh
+++ b/1.8.3/armhf/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -10,13 +10,21 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Add openhab user & handle possible device groups for different host systems

--- a/1.8.3/i386/debian/Dockerfile
+++ b/1.8.3/i386/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/1.8.3/i386/debian/entrypoint.sh
+++ b/1.8.3/i386/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.0.0/amd64/debian/entrypoint.sh
+++ b/2.0.0/amd64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.0.0/arm64/debian/entrypoint.sh
+++ b/2.0.0/arm64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.0.0/armhf/debian/entrypoint.sh
+++ b/2.0.0/armhf/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.0.0/i386/debian/Dockerfile
+++ b/2.0.0/i386/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.0.0/i386/debian/entrypoint.sh
+++ b/2.0.0/i386/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.1.0/amd64/debian/entrypoint.sh
+++ b/2.1.0/amd64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.1.0/arm64/debian/entrypoint.sh
+++ b/2.1.0/arm64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.1.0/armhf/debian/entrypoint.sh
+++ b/2.1.0/armhf/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.1.0/i386/debian/Dockerfile
+++ b/2.1.0/i386/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.1.0/i386/debian/entrypoint.sh
+++ b/2.1.0/i386/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.2.0/amd64/debian/entrypoint.sh
+++ b/2.2.0/amd64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.2.0/arm64/debian/entrypoint.sh
+++ b/2.2.0/arm64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.2.0/armhf/debian/entrypoint.sh
+++ b/2.2.0/armhf/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.2.0/i386/alpine/Dockerfile
+++ b/2.2.0/i386/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.2.0/i386/debian/Dockerfile
+++ b/2.2.0/i386/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.2.0/i386/debian/entrypoint.sh
+++ b/2.2.0/i386/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.3.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.3.0-snapshot/amd64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.3.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.3.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.3.0-snapshot/amd64/debian/Dockerfile
+++ b/2.3.0-snapshot/amd64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.3.0-snapshot/amd64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.3.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.3.0-snapshot/arm64/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.3.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.3.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.3.0-snapshot/arm64/debian/Dockerfile
+++ b/2.3.0-snapshot/arm64/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.3.0-snapshot/arm64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.3.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.3.0-snapshot/armhf/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.3.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.3.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.3.0-snapshot/armhf/debian/Dockerfile
+++ b/2.3.0-snapshot/armhf/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.3.0-snapshot/armhf/debian/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/2.3.0-snapshot/i386/alpine/Dockerfile
+++ b/2.3.0-snapshot/i386/alpine/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -59,6 +60,11 @@ RUN apk update && \
     zip \
     su-exec && \
     rm -rf /var/cache/apk/*
+
+# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
+RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!

--- a/2.3.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/i386/alpine/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/2.3.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/i386/alpine/entrypoint.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.3.0-snapshot/i386/debian/Dockerfile
+++ b/2.3.0-snapshot/i386/debian/Dockerfile
@@ -17,9 +17,10 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     OPENHAB_HTTP_PORT="8080" \
     OPENHAB_HTTPS_PORT="8443" \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    CRYPTO_POLICY="limited"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -53,7 +54,7 @@ RUN apt-get update && \
     wget \
     zip && \
     rm -rf /var/lib/apt/lists/* && \
-ln -s -f /bin/true /usr/bin/chfn
+    ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
@@ -63,10 +64,6 @@ RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
-RUN cd /tmp \
-    && wget https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip \
-    && unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip \
-    && rm /tmp/ZuluJCEPolicies.zip
 
 # Install gosu
 ENV GOSU_VERSION 1.10

--- a/2.3.0-snapshot/i386/debian/entrypoint.sh
+++ b/2.3.0-snapshot/i386/debian/entrypoint.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Repository for building Docker containers for [openHAB](http://openhab.org) (Hom
 **Distributions:**
 
 * ``debian`` for debian jessie
-* ``alpine`` for alpine 3.6
+* ``alpine`` for alpine 3.7
 
 The alpine images are substantially smaller than the debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://docs.openhab.org/installation/#prerequisites) for known disadvantages).
 
@@ -189,6 +189,9 @@ You can run a new container with the command ``docker run -it openhab/openhab:2.
 *  `OPENHAB_HTTPS_PORT`=8443
 *  `USER_ID`=9001
 *  `GROUP_ID`=9001
+*  `CRYPTO_POLICY`=limited
+
+### User and group identifiers
 
 Group id will default to the same value as the user id. By default the openHAB user in the container is running with:
 
@@ -210,6 +213,15 @@ docker run \
 --user <myownuserid> \
 -e USER_ID=<myownuserid>
 ```
+
+### Java cryptographic strength policy
+
+Due to local laws and export restrictions the containers use Java with a limited cryptographic strength policy. Some openHAB functionality (e.g. KM200 binding) may depend on unlimited strength which can be enabled by configuring the environment variable `CRYPTO_POLICY`=unlimited 
+
+Before enabling this make sure this is allowed by local laws and you agree with the applicable license and terms:
+
+* debian: [Zulu (Cryptography Extension Kit)](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-cryptography-extension-kit)
+* alpine: [OpenJDK (Cryptographic Cautions)](http://openjdk.java.net/groups/security)
 
 ## Parameters
 

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
+echo "Installing OpenJDK unlimited strength cryptography policy..."
+  apk update
+  apk fix --no-cache openjdk8-jre-lib
+  rm -rf /var/cache/apk/*
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties
@@ -24,7 +32,7 @@ rm -f /openhab/userdata/tmp/instances/instance.properties
 NEW_USER_ID=${USER_ID:-9001}
 echo "Starting with openhab user id: $NEW_USER_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id 9001"
+  echo "Create user openhab with id $NEW_USER_ID"
   adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
 fi
 

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -12,10 +12,8 @@ IFS=$'\n\t'
 
 # Install Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-echo "Installing OpenJDK unlimited strength cryptography policy..."
-  apk update
+  echo "Installing OpenJDK unlimited strength cryptography policy..."
   apk fix --no-cache openjdk8-jre-lib
-  rm -rf /var/cache/apk/*
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/entrypoint_debian.sh
+++ b/entrypoint_debian.sh
@@ -10,6 +10,14 @@ fi
 set -euo pipefail
 IFS=$'\n\t'
 
+# Install Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
+  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
+  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
+  unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/ZuluJCEPolicies.zip
+  rm /tmp/ZuluJCEPolicies.zip
+fi
+
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f /openhab/runtime/instances/instance.properties


### PR DESCRIPTION
* Use limited strength in debian and alpine containers by default
* Add CRYPTO_POLICY environment variable to install unlimited strength on first start when value is set to "unlimited"
* Update documentation

Fixes #118

Ready for review by @cniweb, @martinvw, @smerschjohann, @rkoshak

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/154)
<!-- Reviewable:end -->
