### PR TITLE
Upgrade to Debian Stretch and cleanup images

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,7 +73,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,6 +73,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-jessie
+FROM multiarch/debian-debootstrap:amd64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" 	    OPENHAB_VERSION="1.8.3"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -87,6 +91,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,7 +73,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,6 +73,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-jessie
+FROM multiarch/debian-debootstrap:arm64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" 	    OPENHAB_VERSION="1.8.3"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,16 +74,18 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    libc6:armhf && \
-    rm -rf /var/lib/apt/lists/*
+    libc6:armhf
 
 # Install openhab
 RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
@@ -93,6 +96,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,7 +73,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,6 +73,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" 	    OPENHAB_VERSION="1.8.3"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -87,6 +91,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,7 +73,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -75,6 +73,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/1.8.3/i386/debian/Dockerfile
+++ b/1.8.3/i386/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/1.8.3/i386/debian/Dockerfile
+++ b/1.8.3/i386/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:i386-jessie
+FROM multiarch/debian-debootstrap:i386-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" 	    OPENHAB_VERSION="1.8.3"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -87,6 +91,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-jessie
+FROM multiarch/debian-debootstrap:amd64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" 	    OPENHAB_VERSION="2.0.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-jessie
+FROM multiarch/debian-debootstrap:arm64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" 	    OPENHAB_VERSION="2.0.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,16 +74,18 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    libc6:armhf && \
-    rm -rf /var/lib/apt/lists/*
+    libc6:armhf
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!
@@ -97,6 +100,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" 	    OPENHAB_VERSION="2.0.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.0.0/i386/debian/Dockerfile
+++ b/2.0.0/i386/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:i386-jessie
+FROM multiarch/debian-debootstrap:i386-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" 	    OPENHAB_VERSION="2.0.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.0.0/i386/debian/Dockerfile
+++ b/2.0.0/i386/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-jessie
+FROM multiarch/debian-debootstrap:amd64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" 	    OPENHAB_VERSION="2.1.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-jessie
+FROM multiarch/debian-debootstrap:arm64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" 	    OPENHAB_VERSION="2.1.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,16 +74,18 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    libc6:armhf && \
-    rm -rf /var/lib/apt/lists/*
+    libc6:armhf
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!
@@ -97,6 +100,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" 	    OPENHAB_VERSION="2.1.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.1.0/i386/debian/Dockerfile
+++ b/2.1.0/i386/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.1.0/i386/debian/Dockerfile
+++ b/2.1.0/i386/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:i386-jessie
+FROM multiarch/debian-debootstrap:i386-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" 	    OPENHAB_VERSION="2.1.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-jessie
+FROM multiarch/debian-debootstrap:amd64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" 	    OPENHAB_VERSION="2.2.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-jessie
+FROM multiarch/debian-debootstrap:arm64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" 	    OPENHAB_VERSION="2.2.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,16 +74,18 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    libc6:armhf && \
-    rm -rf /var/lib/apt/lists/*
+    libc6:armhf
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!
@@ -97,6 +100,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" 	    OPENHAB_VERSION="2.2.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/i386/alpine/Dockerfile
+++ b/2.2.0/i386/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.2.0/i386/alpine/Dockerfile
+++ b/2.2.0/i386/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.2.0/i386/debian/Dockerfile
+++ b/2.2.0/i386/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.2.0/i386/debian/Dockerfile
+++ b/2.2.0/i386/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:i386-jessie
+FROM multiarch/debian-debootstrap:i386-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" 	    OPENHAB_VERSION="2.2.0"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.3.0-snapshot/amd64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.3.0-snapshot/amd64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.3.0-snapshot/amd64/debian/Dockerfile
+++ b/2.3.0-snapshot/amd64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.3.0-snapshot/amd64/debian/Dockerfile
+++ b/2.3.0-snapshot/amd64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-jessie
+FROM multiarch/debian-debootstrap:amd64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.3.0-SNAPSHOT.zip" 	    OPENHAB_VERSION="2.3.0-snapshot"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.3.0-snapshot/arm64/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.3.0-snapshot/arm64/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.3.0-snapshot/arm64/debian/Dockerfile
+++ b/2.3.0-snapshot/arm64/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.3.0-snapshot/arm64/debian/Dockerfile
+++ b/2.3.0-snapshot/arm64/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-jessie
+FROM multiarch/debian-debootstrap:arm64-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.3.0-SNAPSHOT.zip" 	    OPENHAB_VERSION="2.3.0-snapshot"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,16 +74,18 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    libc6:armhf && \
-    rm -rf /var/lib/apt/lists/*
+    libc6:armhf
 
 # Install openhab
 # Set permissions for openhab. Export TERM variable. See issue #30 for details!
@@ -97,6 +100,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.3.0-snapshot/armhf/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.3.0-snapshot/armhf/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.3.0-snapshot/armhf/debian/Dockerfile
+++ b/2.3.0-snapshot/armhf/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_aarch32hf.tar.gz" 	    OPENHAB_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.3.0-SNAPSHOT.zip" 	    OPENHAB_VERSION="2.3.0-snapshot"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/armhf/debian/Dockerfile
+++ b/2.3.0-snapshot/armhf/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/2.3.0-snapshot/i386/alpine/Dockerfile
+++ b/2.3.0-snapshot/i386/alpine/Dockerfile
@@ -53,13 +53,11 @@ RUN apk update && \
     dpkg \
     gnupg \
     wget \
-    curl \
     bash \
     shadow \
     openjdk8 \
     zip \
-    su-exec && \
-    rm -rf /var/cache/apk/*
+    su-exec
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,6 +77,10 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN apk del dpkg gnupg && \
+    rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/i386/alpine/Dockerfile
+++ b/2.3.0-snapshot/i386/alpine/Dockerfile
@@ -42,22 +42,20 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     maintainer="openHAB <info@openhabfoundation.org>"
 
 # Install basepackages
-RUN apk update && \
-    apk upgrade && \
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    bash \
     ca-certificates \
     fontconfig \
-    ttf-dejavu \
     libpcap-dev \
-    unzip \
-    dpkg \
-    gnupg \
-    wget \
-    bash \
     shadow \
+    su-exec \
+    ttf-dejavu \
     openjdk8 \
-    zip \
-    su-exec
+    unzip \
+    wget \
+    zip
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
@@ -79,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
 
 # Reduce image size by removing files that are used only for building the image
-RUN apk del dpkg gnupg && \
+RUN apk del build-dependencies && \
     rm -rf /var/cache/apk/*
 
 # Set working directory, expose and entrypoint

--- a/2.3.0-snapshot/i386/debian/Dockerfile
+++ b/2.3.0-snapshot/i386/debian/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:i386-jessie
+FROM multiarch/debian-debootstrap:i386-stretch
 
 # Set download urls
 ENV 	    JAVA_URL="https://www.azul.com/downloads/zulu/zdk-8-ga-linux_x64.tar.gz" 	    OPENHAB_URL="https://openhab.ci.cloudbees.com/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.3.0-SNAPSHOT.zip" 	    OPENHAB_VERSION="2.3.0-snapshot"
@@ -45,7 +45,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    dirmngr \
     fontconfig \
+    gnupg \
     locales \
     locales-all \
     libpcap-dev \
@@ -53,14 +55,13 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
-    rm -rf /var/lib/apt/lists/* && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java
 ENV JAVA_HOME='/usr/lib/java-8'
 RUN wget -nv -O /tmp/java.tar.gz ${JAVA_URL} && \
     mkdir ${JAVA_HOME} && \
-    tar -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
+    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xvf /tmp/java.tar.gz --strip-components=1 -C ${JAVA_HOME} && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 50 && \
     update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 50
@@ -73,9 +74,12 @@ RUN set -x \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
+       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
+       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # Install openhab
@@ -91,6 +95,11 @@ RUN wget -nv -O /tmp/openhab.zip ${OPENHAB_URL} && \
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+
+# Reduce image size by removing files that are used only for building the image
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y dirmngr gnupg && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory, expose and entrypoint
 WORKDIR ${APPDIR}

--- a/2.3.0-snapshot/i386/debian/Dockerfile
+++ b/2.3.0-snapshot/i386/debian/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && \
     dirmngr \
     fontconfig \
     gnupg \
+    libpcap-dev \
     locales \
     locales-all \
-    libpcap-dev \
     netbase \
     unzip \
     wget \

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Repository for building Docker containers for [openHAB](http://openhab.org) (Hom
 
 **Distributions:**
 
-* ``debian`` for debian jessie
+* ``debian`` for debian stretch
 * ``alpine`` for alpine 3.7
 
 The alpine images are substantially smaller than the debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://docs.openhab.org/installation/#prerequisites) for known disadvantages).
@@ -177,7 +177,7 @@ The default password for the login is ``habopen``.
 
 **Debug Mode**
 
-You can run a new container with the command ``docker run -it openhab/openhab:2.2.0-amd64 ./start_debug.sh`` to get into the debug shell.
+You can run a new container with the command ``docker run -it openhab/openhab:2.2.0-amd64-debian ./start_debug.sh`` to get into the debug shell.
 
 ## Environment variables
 
@@ -240,7 +240,7 @@ Upgrading OH requires changes to the user mapped in userdata folder. The contain
 * Copy over the relevant files from `userdata.dist/etc` to `userdata/etc`.
 * Delete the contents of `userdata/cache` and `userdata/tmp`.
 
-The steps performed are the same as those performed by running the upgrade script that comes with OH, except the backup is performed differently and the latest openHAB runtime is not downloaded, 
+The steps performed are the same as those performed by running the upgrade script that comes with OH, except the backup is performed differently and the latest openHAB runtime is not downloaded.
 
 ## Building the image
 

--- a/update.sh
+++ b/update.sh
@@ -128,9 +128,9 @@ print_basepackages() {
 	    dirmngr \
 	    fontconfig \
 	    gnupg \
+	    libpcap-dev \
 	    locales \
 	    locales-all \
-	    libpcap-dev \
 	    netbase \
 	    unzip \
 	    wget \
@@ -144,22 +144,20 @@ EOI
 print_basepackages_alpine() {
 	cat >> $1 <<-'EOI'
 	# Install basepackages
-	RUN apk update && \
-	    apk upgrade && \
+	RUN apk upgrade --no-cache && \
+	    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
 	    apk add --no-cache \
+	    bash \
 	    ca-certificates \
 	    fontconfig \
-	    ttf-dejavu \
 	    libpcap-dev \
-	    unzip \
-	    dpkg \
-	    gnupg \
-	    wget \
-	    bash \
 	    shadow \
+	    su-exec \
+	    ttf-dejavu \
 	    openjdk8 \
-	    zip \
-	    su-exec
+	    unzip \
+	    wget \
+	    zip
 
 EOI
 }
@@ -179,13 +177,11 @@ EOI
 print_cleanup_alpine() {
 	cat >> $1 <<-'EOI'
 	# Reduce image size by removing files that are used only for building the image
-	RUN apk del dpkg gnupg && \
+	RUN apk del build-dependencies && \
 	    rm -rf /var/cache/apk/*
 
 EOI
 }
-
-
 
 # Print 32-bit for arm64 arch
 print_lib32_support_arm64() {


### PR DESCRIPTION
* Install dirmngr and gnupg during Debian build to be able to validate GPG signatures
* Try multiple GPG key servers because build now fails when retrieval fails and ha.pool.sks-keyservers.net is not that reliable
* Cleanup packages/files that are only required for building containers (dirmngr, dpkg, gnupg)
* Exclude src.zip, demo and example directories when extracting Zulu to reduce Debian container size

With stretch commands like `top` and `ps` are now missing because `procps` is no longer a dependency of the `udev` package. 

Maybe we should add them back by also installing `procps`? WDYT @cniweb, @martinvw ? Perhaps there is also other missing functionality?

With these changes the debian amd64 container size got reduced by about ~50MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/156)
<!-- Reviewable:end -->
