### PR TITLE
Remove necessary files after installation

### DIFF
--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -77,6 +77,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/amd64/debian/entrypoint.sh
+++ b/1.8.3/amd64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -77,6 +77,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/arm64/debian/entrypoint.sh
+++ b/1.8.3/arm64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -77,6 +77,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/armhf/debian/entrypoint.sh
+++ b/1.8.3/armhf/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -77,6 +77,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/1.8.3/i386/debian/entrypoint.sh
+++ b/1.8.3/i386/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/amd64/debian/entrypoint.sh
+++ b/2.0.0/amd64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/arm64/debian/entrypoint.sh
+++ b/2.0.0/arm64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/armhf/debian/entrypoint.sh
+++ b/2.0.0/armhf/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.0.0/i386/debian/entrypoint.sh
+++ b/2.0.0/i386/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/amd64/debian/entrypoint.sh
+++ b/2.1.0/amd64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/arm64/debian/entrypoint.sh
+++ b/2.1.0/arm64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/armhf/debian/entrypoint.sh
+++ b/2.1.0/armhf/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.1.0/i386/debian/entrypoint.sh
+++ b/2.1.0/i386/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/amd64/debian/entrypoint.sh
+++ b/2.2.0/amd64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/arm64/debian/entrypoint.sh
+++ b/2.2.0/arm64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/armhf/debian/entrypoint.sh
+++ b/2.2.0/armhf/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.2.0/i386/debian/entrypoint.sh
+++ b/2.2.0/i386/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/amd64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/amd64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/arm64/debian/entrypoint.sh
+++ b/2.3.0-snapshot/arm64/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/armhf/debian/entrypoint.sh
+++ b/2.3.0-snapshot/armhf/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.3.0-snapshot/i386/alpine/entrypoint.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/2.3.0-snapshot/i386/debian/entrypoint.sh
+++ b/2.3.0-snapshot/i386/debian/entrypoint.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -85,6 +85,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"

--- a/entrypoint_debian.sh
+++ b/entrypoint_debian.sh
@@ -102,6 +102,12 @@ case ${OPENHAB_VERSION} in
         cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
         echo "Replaced files in userdata/etc with newer versions"
 
+        # Remove necessary files after installation
+        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
+        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
+          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
+        fi
+
         # Clear the cache and tmp
         rm -rf "${APPDIR}/userdata/cache"
         rm -rf "${APPDIR}/userdata/tmp"


### PR DESCRIPTION
Fixes #165

It will only remove `overrides.properties` when it's not provided. Otherwise 2.2.0 or future versions will no longer work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/166)
<!-- Reviewable:end -->
