### PR TITLE
Add arping package

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/1.8.3/i386/debian/Dockerfile
+++ b/1.8.3/i386/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.0.0/i386/debian/Dockerfile
+++ b/2.0.0/i386/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.1.0/i386/debian/Dockerfile
+++ b/2.1.0/i386/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.2.0/i386/alpine/Dockerfile
+++ b/2.2.0/i386/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.2.0/i386/debian/Dockerfile
+++ b/2.2.0/i386/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.3.0/amd64/alpine/Dockerfile
+++ b/2.3.0/amd64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.3.0/amd64/debian/Dockerfile
+++ b/2.3.0/amd64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.3.0/arm64/alpine/Dockerfile
+++ b/2.3.0/arm64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.3.0/arm64/debian/Dockerfile
+++ b/2.3.0/arm64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.3.0/armhf/alpine/Dockerfile
+++ b/2.3.0/armhf/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.3.0/armhf/debian/Dockerfile
+++ b/2.3.0/armhf/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.3.0/i386/alpine/Dockerfile
+++ b/2.3.0/i386/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.3.0/i386/debian/Dockerfile
+++ b/2.3.0/i386/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.4.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.4.0-snapshot/amd64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.4.0-snapshot/amd64/debian/Dockerfile
+++ b/2.4.0-snapshot/amd64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.4.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.4.0-snapshot/arm64/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.4.0-snapshot/arm64/debian/Dockerfile
+++ b/2.4.0-snapshot/arm64/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.4.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.4.0-snapshot/armhf/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.4.0-snapshot/armhf/debian/Dockerfile
+++ b/2.4.0-snapshot/armhf/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/2.4.0-snapshot/i386/alpine/Dockerfile
+++ b/2.4.0-snapshot/i386/alpine/Dockerfile
@@ -45,6 +45,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual build-dependencies dpkg gnupg && \
     apk add --no-cache \
+    arping \
     bash \
     ca-certificates \
     fontconfig \

--- a/2.4.0-snapshot/i386/debian/Dockerfile
+++ b/2.4.0-snapshot/i386/debian/Dockerfile
@@ -44,6 +44,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # Install basepackages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    arping \
     ca-certificates \
     dirmngr \
     fontconfig \

--- a/update.sh
+++ b/update.sh
@@ -127,6 +127,7 @@ print_basepackages() {
 	# Install basepackages
 	RUN apt-get update && \
 	    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+	    arping \
 	    ca-certificates \
 	    dirmngr \
 	    fontconfig \
@@ -150,6 +151,7 @@ print_basepackages_alpine() {
 	RUN apk upgrade --no-cache && \
 	    apk add --no-cache --virtual build-dependencies dpkg gnupg && \
 	    apk add --no-cache \
+	    arping \
 	    bash \
 	    ca-certificates \
 	    fontconfig \


### PR DESCRIPTION
This closes https://github.com/openhab/openhab-docker/issues/158

Similar to https://github.com/openhab/openhabian/pull/311

The Network Binding add-on works better with the arping package, so while it's not a dependency of the core openhab app it seems worthwhile to add since the Network Binding is widely used I suspect.

Note that the Dockerfiles previously had a mixture of tabs and spaces for indenting. I don't care either way, but since tabs seems to be the most used indent, I changed spaces to tabs (except for where spaces are used to pretty-print messages).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/175)
<!-- Reviewable:end -->
