### PR TITLE
Set setuid flag on arping

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/1.8.3/i386/debian/Dockerfile
+++ b/1.8.3/i386/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.0.0/i386/debian/Dockerfile
+++ b/2.0.0/i386/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.1.0/i386/debian/Dockerfile
+++ b/2.1.0/i386/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.2.0/i386/alpine/Dockerfile
+++ b/2.2.0/i386/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.2.0/i386/debian/Dockerfile
+++ b/2.2.0/i386/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.3.0/amd64/alpine/Dockerfile
+++ b/2.3.0/amd64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.3.0/amd64/debian/Dockerfile
+++ b/2.3.0/amd64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.3.0/arm64/alpine/Dockerfile
+++ b/2.3.0/arm64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.3.0/arm64/debian/Dockerfile
+++ b/2.3.0/arm64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.3.0/armhf/alpine/Dockerfile
+++ b/2.3.0/armhf/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.3.0/armhf/debian/Dockerfile
+++ b/2.3.0/armhf/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.3.0/i386/alpine/Dockerfile
+++ b/2.3.0/i386/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.3.0/i386/debian/Dockerfile
+++ b/2.3.0/i386/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.4.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.4.0-snapshot/amd64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.4.0-snapshot/amd64/debian/Dockerfile
+++ b/2.4.0-snapshot/amd64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.4.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.4.0-snapshot/arm64/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.4.0-snapshot/arm64/debian/Dockerfile
+++ b/2.4.0-snapshot/arm64/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.4.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.4.0-snapshot/armhf/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.4.0-snapshot/armhf/debian/Dockerfile
+++ b/2.4.0-snapshot/armhf/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/2.4.0-snapshot/i386/alpine/Dockerfile
+++ b/2.4.0-snapshot/i386/alpine/Dockerfile
@@ -56,7 +56,8 @@ RUN apk upgrade --no-cache && \
     openjdk8 \
     unzip \
     wget \
-    zip
+    zip && \
+    chmod u+s /usr/sbin/arping
 
 # Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'

--- a/2.4.0-snapshot/i386/debian/Dockerfile
+++ b/2.4.0-snapshot/i386/debian/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     unzip \
     wget \
     zip && \
+    chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn
 
 # Install java

--- a/update.sh
+++ b/update.sh
@@ -139,6 +139,7 @@ print_basepackages() {
 	    unzip \
 	    wget \
 	    zip && \
+	    chmod u+s /usr/sbin/arping && \
 	    ln -s -f /bin/true /usr/bin/chfn
 
 EOI
@@ -162,7 +163,8 @@ print_basepackages_alpine() {
 	    openjdk8 \
 	    unzip \
 	    wget \
-	    zip
+	    zip && \
+	    chmod u+s /usr/sbin/arping
 
 EOI
 }


### PR DESCRIPTION
Fixes use of arping when openHAB does not run as root.

See: https://github.com/openhab/openhab-docker/pull/175#issuecomment-397706141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/177)
<!-- Reviewable:end -->
