### PR TITLE
Fix getting GPG keys and groups on Alpine

### DIFF
--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -17,13 +17,18 @@ if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security
 fi
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -17,13 +17,18 @@ if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security
 fi
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -17,13 +17,18 @@ if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security
 fi
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -17,13 +17,18 @@ if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security
 fi
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/1.8.3/i386/debian/Dockerfile
+++ b/1.8.3/i386/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.0.0/i386/debian/Dockerfile
+++ b/2.0.0/i386/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.1.0/i386/debian/Dockerfile
+++ b/2.1.0/i386/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.2.0/i386/debian/Dockerfile
+++ b/2.2.0/i386/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.3.0/amd64/alpine/entrypoint.sh
+++ b/2.3.0/amd64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.3.0/amd64/debian/Dockerfile
+++ b/2.3.0/amd64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.3.0/arm64/alpine/entrypoint.sh
+++ b/2.3.0/arm64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.3.0/arm64/debian/Dockerfile
+++ b/2.3.0/arm64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.3.0/armhf/alpine/entrypoint.sh
+++ b/2.3.0/armhf/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.3.0/armhf/debian/Dockerfile
+++ b/2.3.0/armhf/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.3.0/i386/alpine/entrypoint.sh
+++ b/2.3.0/i386/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.3.0/i386/debian/Dockerfile
+++ b/2.3.0/i386/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.4.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/amd64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.4.0-snapshot/amd64/debian/Dockerfile
+++ b/2.4.0-snapshot/amd64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.4.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/arm64/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.4.0-snapshot/arm64/debian/Dockerfile
+++ b/2.4.0-snapshot/arm64/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.4.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/armhf/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.4.0-snapshot/armhf/debian/Dockerfile
+++ b/2.4.0-snapshot/armhf/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/2.4.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/i386/alpine/entrypoint.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/2.4.0-snapshot/i386/debian/Dockerfile
+++ b/2.4.0-snapshot/i386/debian/Dockerfile
@@ -77,9 +77,8 @@ RUN set -x \
     && export GNUPGHOME \
     && GNUPGHOME="$(mktemp -d)" \
     && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -25,13 +25,18 @@ rm -f /openhab/runtime/instances/instance.properties
 rm -f /openhab/userdata/tmp/instances/instance.properties
 
 # Add openhab user & handle possible device groups for different host systems
-# Container base image puts dialout on group id 20, uucp on id 10
+# Container base image puts dialout on group id 20, uucp on id 14
 # GPIO Group for RPI access
 NEW_USER_ID=${USER_ID:-9001}
-echo "Starting with openhab user id: $NEW_USER_ID"
+NEW_GROUP_ID=${GROUP_ID:-$NEW_USER_ID}
+echo "Starting with openhab user id: $NEW_USER_ID and group id: $NEW_GROUP_ID"
 if ! id -u openhab >/dev/null 2>&1; then
-  echo "Create user openhab with id $NEW_USER_ID"
-  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} openhab
+  echo "Create group openhab with id ${NEW_GROUP_ID}"
+  addgroup -g $NEW_GROUP_ID openhab
+  echo "Create user openhab with id ${NEW_USER_ID}"
+  adduser -u $NEW_USER_ID -D -g '' -h ${APPDIR} -G openhab openhab
+  adduser openhab dialout
+  adduser openhab uucp
 fi
 
 # Copy initial files to host volume

--- a/update.sh
+++ b/update.sh
@@ -213,9 +213,8 @@ print_gosu() {
 	    && export GNUPGHOME \
 	    && GNUPGHOME="$(mktemp -d)" \
 	    && GPG_KEY="B42F6819007F00F88E364FD4036A9C25BF357DD4" \
-	    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY \
-	       || gpg --keyserver pgp.mit.edu --recv-keys $GPG_KEY \
-	       || gpg --keyserver keyserver.pgp.com --recv-keys $GPG_KEY \
+	    && KEYSERVERS=$(shuf -e $(echo "ha.pool.sks-keyservers.net\nhkp://p80.pool.sks-keyservers.net:80\nkeyserver.ubuntu.com\nhkp://keyserver.ubuntu.com:80\npgp.mit.edu\nhkp://pgp.mit.edu:80")) \
+	    && for i in $(seq 1 3); do for keyserver in $KEYSERVERS; do gpg --verbose --keyserver $keyserver --recv-keys $GPG_KEY && break; done; if [ $? -eq 0 ]; then break; fi done \
 	    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	    && chmod +x /usr/local/bin/gosu


### PR DESCRIPTION
Often Travis fails to build all containers because the gosu GPG key fails to download.
The following changes should make this more stable:

* Update GPG keyserver list
  * Remove keyserver.pgp.com from list since it does not have the gosu GPG key
  * Add keyserver.ubuntu.com to list which does have the gosu GPG key
  * Add port 80 only variants to prevent possible firewall issues
* Shuffle keyserver list to spread load over keyservers
* Retry 3 times before giving up

Add commands to Alpine entrypoint to use GROUP_ID environment variable.
Fixes #169.

CC: @cniweb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/178)
<!-- Reviewable:end -->
