### PR TITLE
Use server mode when there is no pseudo-TTY

### DIFF
--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -110,4 +104,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -110,4 +104,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -110,4 +104,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/1.8.3/i386/alpine/entrypoint.sh
+++ b/1.8.3/i386/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -110,4 +104,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.0.0/i386/alpine/entrypoint.sh
+++ b/2.0.0/i386/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.1.0/i386/alpine/entrypoint.sh
+++ b/2.1.0/i386/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.2.0/i386/alpine/entrypoint.sh
+++ b/2.2.0/i386/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.3.0/amd64/alpine/entrypoint.sh
+++ b/2.3.0/amd64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.3.0/arm64/alpine/entrypoint.sh
+++ b/2.3.0/arm64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.3.0/armhf/alpine/entrypoint.sh
+++ b/2.3.0/armhf/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.3.0/i386/alpine/entrypoint.sh
+++ b/2.3.0/i386/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.4.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/amd64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.4.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/arm64/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.4.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/armhf/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/2.4.0-snapshot/i386/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/i386/alpine/entrypoint.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi

--- a/entrypoint_alpine.sh
+++ b/entrypoint_alpine.sh
@@ -1,12 +1,6 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
-# Karaf needs a pseudo-TTY so exit and instruct user to allocate one when necessary
-test -t 0
-if [ $? -eq 1 ]; then
-    echo "Please start the openHAB container with a pseudo-TTY using the -t option or 'tty: true' with docker compose"
-    exit 1
-fi
-
+interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -118,4 +112,10 @@ esac
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 
-exec "$@"
+# Use server mode with the default command when there is no pseudo-TTY
+if [ "$interactive" == "false" ] && [ "$(IFS=" "; echo "$@")" == "su-exec openhab ./start.sh" ]; then
+    command=($@ server)
+    exec "${command[@]}"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
With this PR the container will use the availability of a TTY to determine the Karaf startup mode: 
* a Karaf console is started when a TTY is detected (the current behavior)
* server mode is started when no TTY is detected

This way it will be possible again to start the container without a TTY. 

When the container runs in server mode you can also add a console logger so it prints logging to stdout so you can check logging with `docker logs containername`.
 E.g. edit `userdata/etc/org.ops4j.pax.logging.cfg` and then:
  * update line: `log4j2.rootLogger.appenderRefs = out, osgi, console`
  * add line: `log4j2.rootLogger.appenderRef.console.ref = STDOUT`

Also we no longer need to always instruct users to start the container with a TTY (https://github.com/openhab/openhab-docker/pull/141).

Other improvements:
* Updated shell of entrypoint.sh on Alpine to /bin/bash (similar to Debian container)
* Updated permissions of all shell scripts (.sh) files to 755

Running Karaf in server mode may also prevent exceptions on platforms where the jansi library fails to load (see https://github.com/openhab/openhab-docker/issues/170#issuecomment-398357476).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/181)
<!-- Reviewable:end -->
