### PR TITLE
Upgrade to Alpine v3.8

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.7
+FROM multiarch/alpine:amd64-v3.8
 
 # Set download urls
 ENV \

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.7
+FROM multiarch/alpine:arm64-v3.8
 
 # Set download urls
 ENV \

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.7
+FROM multiarch/alpine:armhf-v3.8
 
 # Set download urls
 ENV \

--- a/1.8.3/i386/alpine/Dockerfile
+++ b/1.8.3/i386/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:i386-v3.7
+FROM multiarch/alpine:i386-v3.8
 
 # Set download urls
 ENV \

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.7
+FROM multiarch/alpine:amd64-v3.8
 
 # Set download urls
 ENV \

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.7
+FROM multiarch/alpine:arm64-v3.8
 
 # Set download urls
 ENV \

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.7
+FROM multiarch/alpine:armhf-v3.8
 
 # Set download urls
 ENV \

--- a/2.0.0/i386/alpine/Dockerfile
+++ b/2.0.0/i386/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:i386-v3.7
+FROM multiarch/alpine:i386-v3.8
 
 # Set download urls
 ENV \

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.7
+FROM multiarch/alpine:amd64-v3.8
 
 # Set download urls
 ENV \

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.7
+FROM multiarch/alpine:arm64-v3.8
 
 # Set download urls
 ENV \

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.7
+FROM multiarch/alpine:armhf-v3.8
 
 # Set download urls
 ENV \

--- a/2.1.0/i386/alpine/Dockerfile
+++ b/2.1.0/i386/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:i386-v3.7
+FROM multiarch/alpine:i386-v3.8
 
 # Set download urls
 ENV \

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.7
+FROM multiarch/alpine:amd64-v3.8
 
 # Set download urls
 ENV \

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.7
+FROM multiarch/alpine:arm64-v3.8
 
 # Set download urls
 ENV \

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.7
+FROM multiarch/alpine:armhf-v3.8
 
 # Set download urls
 ENV \

--- a/2.2.0/i386/alpine/Dockerfile
+++ b/2.2.0/i386/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:i386-v3.7
+FROM multiarch/alpine:i386-v3.8
 
 # Set download urls
 ENV \

--- a/2.3.0/amd64/alpine/Dockerfile
+++ b/2.3.0/amd64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.7
+FROM multiarch/alpine:amd64-v3.8
 
 # Set download urls
 ENV \

--- a/2.3.0/arm64/alpine/Dockerfile
+++ b/2.3.0/arm64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.7
+FROM multiarch/alpine:arm64-v3.8
 
 # Set download urls
 ENV \

--- a/2.3.0/armhf/alpine/Dockerfile
+++ b/2.3.0/armhf/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.7
+FROM multiarch/alpine:armhf-v3.8
 
 # Set download urls
 ENV \

--- a/2.3.0/i386/alpine/Dockerfile
+++ b/2.3.0/i386/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:i386-v3.7
+FROM multiarch/alpine:i386-v3.8
 
 # Set download urls
 ENV \

--- a/2.4.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.4.0-snapshot/amd64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.7
+FROM multiarch/alpine:amd64-v3.8
 
 # Set download urls
 ENV \

--- a/2.4.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.4.0-snapshot/arm64/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.7
+FROM multiarch/alpine:arm64-v3.8
 
 # Set download urls
 ENV \

--- a/2.4.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.4.0-snapshot/armhf/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.7
+FROM multiarch/alpine:armhf-v3.8
 
 # Set download urls
 ENV \

--- a/2.4.0-snapshot/i386/alpine/Dockerfile
+++ b/2.4.0-snapshot/i386/alpine/Dockerfile
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:i386-v3.7
+FROM multiarch/alpine:i386-v3.8
 
 # Set download urls
 ENV \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Comments, suggestions and contributions are welcome!
 **Distributions:**
 
 * `debian` for debian stretch
-* `alpine` for alpine 3.7
+* `alpine` for alpine 3.8
 
 The alpine images are substantially smaller than the debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).
 

--- a/update.sh
+++ b/update.sh
@@ -66,7 +66,7 @@ print_baseimage() {
 		base_image="debian-debootstrap:$arch-stretch"
 		;;
 	alpine)
-		base_image="alpine:$arch-v3.7"
+		base_image="alpine:$arch-v3.8"
 		;;
 	default)
 		base_image="error"


### PR DESCRIPTION
Upgrades the Alpine images to v3.8 which was released yesterday.

See also: https://alpinelinux.org/posts/Alpine-3.8.0-released.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/183)
<!-- Reviewable:end -->
