### PR TITLE
correct timezone for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ docker run \
         -v openhab_addons:/openhab/addons \
         -v openhab_conf:/openhab/conf \
         -v openhab_userdata:/openhab/userdata \
+        -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/YourTZCity" \
         -d \
         --restart=always \
         openhab/openhab:2.3.0-amd64-debian
@@ -126,6 +127,7 @@ services:
     environment:
       OPENHAB_HTTP_PORT: "8080"
       OPENHAB_HTTPS_PORT: "8443"
+      EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/YourTZCity"
 ```
 
 #### Running openHAB with libpcap support
@@ -174,6 +176,7 @@ docker run \
   -v /opt/openhab/addons:/openhab/addons \
   -v /opt/openhab/conf:/openhab/conf \
   -v /opt/openhab/userdata:/openhab/userdata \
+  -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/YourTZCity" \
   openhab/openhab:2.3.0-amd64-debian
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker run \
         -v openhab_addons:/openhab/addons \
         -v openhab_conf:/openhab/conf \
         -v openhab_userdata:/openhab/userdata \
-        -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/YourTZCity" \
+        -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/Berlin" \
         -d \
         --restart=always \
         openhab/openhab:2.3.0-amd64-debian
@@ -127,7 +127,7 @@ services:
     environment:
       OPENHAB_HTTP_PORT: "8080"
       OPENHAB_HTTPS_PORT: "8443"
-      EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/YourTZCity"
+      EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/Berlin"
 ```
 
 #### Running openHAB with libpcap support
@@ -176,7 +176,7 @@ docker run \
   -v /opt/openhab/addons:/openhab/addons \
   -v /opt/openhab/conf:/openhab/conf \
   -v /opt/openhab/userdata:/openhab/userdata \
-  -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/YourTZCity" \
+  -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/Berlin" \
   openhab/openhab:2.3.0-amd64-debian
 ```
 


### PR DESCRIPTION
I spent some time last night wondering why my rules execute in UTC time instead of local time. Then I found the solution, and it would be nice if you could add the info on the README, as it already instructs how to set system time. Which is not enough to set it for Java. So perhaps this line could be addded:

        -e "EXTRA_JAVA_OPTS=-Duser.timezone=Europe/YourTZCity" \

Which then sets the Java to run in correct timezone, and rules work in correct times along with properly timed logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/185)
<!-- Reviewable:end -->
