### PR TITLE
Fix #187 by removing legacy e-mail option from docker login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - docker build --build-arg VCS_REF=$TRAVIS_COMMIT --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg VERSION=$VERSION -t $DOCKER_REPO:$VERSION-$TARGET-$DIST $VERSION/$TARGET/$DIST
   - docker run --rm $DOCKER_REPO:$VERSION-$TARGET-$DIST uname -a
 after_success:
-  - docker login -e=$DOCKER_EMAIL -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
+  - docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
   - docker push $DOCKER_REPO:$VERSION-$TARGET-$DIST
 env:
   #global:


### PR DESCRIPTION
The e-mail option was already deprecated for some time but it seems to have been removed from the command now causing the login to fail.

See also: https://docs.docker.com/engine/deprecated/#-e-and---email-flags-on-docker-login

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/188)
<!-- Reviewable:end -->
