### PR TITLE
Initial support for local scripts as used in s6 init

### DIFF
--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -101,6 +101,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/1.8.3/amd64/debian/entrypoint.sh
+++ b/1.8.3/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -101,6 +101,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/1.8.3/arm64/debian/entrypoint.sh
+++ b/1.8.3/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -101,6 +101,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/1.8.3/armhf/debian/entrypoint.sh
+++ b/1.8.3/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.0.0/amd64/debian/entrypoint.sh
+++ b/2.0.0/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.0.0/arm64/debian/entrypoint.sh
+++ b/2.0.0/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.0.0/armhf/debian/entrypoint.sh
+++ b/2.0.0/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.1.0/amd64/debian/entrypoint.sh
+++ b/2.1.0/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.1.0/arm64/debian/entrypoint.sh
+++ b/2.1.0/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.1.0/armhf/debian/entrypoint.sh
+++ b/2.1.0/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.2.0/amd64/debian/entrypoint.sh
+++ b/2.2.0/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.2.0/arm64/debian/entrypoint.sh
+++ b/2.2.0/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.2.0/armhf/debian/entrypoint.sh
+++ b/2.2.0/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.3.0/amd64/alpine/entrypoint.sh
+++ b/2.3.0/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.3.0/amd64/debian/entrypoint.sh
+++ b/2.3.0/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.3.0/arm64/alpine/entrypoint.sh
+++ b/2.3.0/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.3.0/arm64/debian/entrypoint.sh
+++ b/2.3.0/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.3.0/armhf/alpine/entrypoint.sh
+++ b/2.3.0/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.3.0/armhf/debian/entrypoint.sh
+++ b/2.3.0/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0-snapshot/amd64/debian/entrypoint.sh
+++ b/2.4.0-snapshot/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0-snapshot/arm64/debian/entrypoint.sh
+++ b/2.4.0-snapshot/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0-snapshot/armhf/debian/entrypoint.sh
+++ b/2.4.0-snapshot/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M3/amd64/alpine/entrypoint.sh
+++ b/2.4.0.M3/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M3/amd64/debian/entrypoint.sh
+++ b/2.4.0.M3/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M3/arm64/alpine/entrypoint.sh
+++ b/2.4.0.M3/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M3/arm64/debian/entrypoint.sh
+++ b/2.4.0.M3/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M3/armhf/alpine/entrypoint.sh
+++ b/2.4.0.M3/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M3/armhf/debian/entrypoint.sh
+++ b/2.4.0.M3/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M4/amd64/alpine/entrypoint.sh
+++ b/2.4.0.M4/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M4/amd64/debian/entrypoint.sh
+++ b/2.4.0.M4/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M4/arm64/alpine/entrypoint.sh
+++ b/2.4.0.M4/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M4/arm64/debian/entrypoint.sh
+++ b/2.4.0.M4/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M4/armhf/alpine/entrypoint.sh
+++ b/2.4.0.M4/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M4/armhf/debian/entrypoint.sh
+++ b/2.4.0.M4/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M5/amd64/alpine/entrypoint.sh
+++ b/2.4.0.M5/amd64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M5/amd64/debian/entrypoint.sh
+++ b/2.4.0.M5/amd64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M5/arm64/alpine/entrypoint.sh
+++ b/2.4.0.M5/arm64/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M5/arm64/debian/entrypoint.sh
+++ b/2.4.0.M5/arm64/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M5/armhf/alpine/entrypoint.sh
+++ b/2.4.0.M5/armhf/alpine/entrypoint.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/2.4.0.M5/armhf/debian/entrypoint.sh
+++ b/2.4.0.M5/armhf/debian/entrypoint.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/entrypoint-alpine.sh
+++ b/entrypoint-alpine.sh
@@ -109,6 +109,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync

--- a/entrypoint-debian.sh
+++ b/entrypoint-debian.sh
@@ -121,6 +121,15 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Run s6-style init continuation scripts if existent
+if [ -d /etc/cont-init.d ]
+then
+    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    do
+        . ${script}
+    done
+fi
+
 # Set openhab folder permission
 chown -R openhab:openhab ${APPDIR}
 sync


### PR DESCRIPTION
See https://skarnet.org/software/s6/

I like the modularity of system setup scripts. In my local setup, I use cont-init.d scripts to expose what has really been configured by the entrypoint script, and pre-generate ssh keys.

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/203)
<!-- Reviewable:end -->
