### PR TITLE
Execute scripts in cont-initd in defined (alphabetical) order

### DIFF
--- a/1.8.3/amd64/alpine/entrypoint.sh
+++ b/1.8.3/amd64/alpine/entrypoint.sh
@@ -105,7 +105,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/1.8.3/amd64/debian/entrypoint.sh
+++ b/1.8.3/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/1.8.3/arm64/alpine/entrypoint.sh
+++ b/1.8.3/arm64/alpine/entrypoint.sh
@@ -105,7 +105,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/1.8.3/arm64/debian/entrypoint.sh
+++ b/1.8.3/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/1.8.3/armhf/alpine/entrypoint.sh
+++ b/1.8.3/armhf/alpine/entrypoint.sh
@@ -105,7 +105,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/1.8.3/armhf/debian/entrypoint.sh
+++ b/1.8.3/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.0.0/amd64/alpine/entrypoint.sh
+++ b/2.0.0/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.0.0/amd64/debian/entrypoint.sh
+++ b/2.0.0/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.0.0/arm64/alpine/entrypoint.sh
+++ b/2.0.0/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.0.0/arm64/debian/entrypoint.sh
+++ b/2.0.0/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.0.0/armhf/alpine/entrypoint.sh
+++ b/2.0.0/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.0.0/armhf/debian/entrypoint.sh
+++ b/2.0.0/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.1.0/amd64/alpine/entrypoint.sh
+++ b/2.1.0/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.1.0/amd64/debian/entrypoint.sh
+++ b/2.1.0/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.1.0/arm64/alpine/entrypoint.sh
+++ b/2.1.0/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.1.0/arm64/debian/entrypoint.sh
+++ b/2.1.0/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.1.0/armhf/alpine/entrypoint.sh
+++ b/2.1.0/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.1.0/armhf/debian/entrypoint.sh
+++ b/2.1.0/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.2.0/amd64/alpine/entrypoint.sh
+++ b/2.2.0/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.2.0/amd64/debian/entrypoint.sh
+++ b/2.2.0/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.2.0/arm64/alpine/entrypoint.sh
+++ b/2.2.0/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.2.0/arm64/debian/entrypoint.sh
+++ b/2.2.0/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.2.0/armhf/alpine/entrypoint.sh
+++ b/2.2.0/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.2.0/armhf/debian/entrypoint.sh
+++ b/2.2.0/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.3.0/amd64/alpine/entrypoint.sh
+++ b/2.3.0/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.3.0/amd64/debian/entrypoint.sh
+++ b/2.3.0/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.3.0/arm64/alpine/entrypoint.sh
+++ b/2.3.0/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.3.0/arm64/debian/entrypoint.sh
+++ b/2.3.0/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.3.0/armhf/alpine/entrypoint.sh
+++ b/2.3.0/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.3.0/armhf/debian/entrypoint.sh
+++ b/2.3.0/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0-snapshot/amd64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0-snapshot/amd64/debian/entrypoint.sh
+++ b/2.4.0-snapshot/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0-snapshot/arm64/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0-snapshot/arm64/debian/entrypoint.sh
+++ b/2.4.0-snapshot/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0-snapshot/armhf/alpine/entrypoint.sh
+++ b/2.4.0-snapshot/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0-snapshot/armhf/debian/entrypoint.sh
+++ b/2.4.0-snapshot/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M3/amd64/alpine/entrypoint.sh
+++ b/2.4.0.M3/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M3/amd64/debian/entrypoint.sh
+++ b/2.4.0.M3/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M3/arm64/alpine/entrypoint.sh
+++ b/2.4.0.M3/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M3/arm64/debian/entrypoint.sh
+++ b/2.4.0.M3/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M3/armhf/alpine/entrypoint.sh
+++ b/2.4.0.M3/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M3/armhf/debian/entrypoint.sh
+++ b/2.4.0.M3/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M4/amd64/alpine/entrypoint.sh
+++ b/2.4.0.M4/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M4/amd64/debian/entrypoint.sh
+++ b/2.4.0.M4/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M4/arm64/alpine/entrypoint.sh
+++ b/2.4.0.M4/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M4/arm64/debian/entrypoint.sh
+++ b/2.4.0.M4/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M4/armhf/alpine/entrypoint.sh
+++ b/2.4.0.M4/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M4/armhf/debian/entrypoint.sh
+++ b/2.4.0.M4/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M5/amd64/alpine/entrypoint.sh
+++ b/2.4.0.M5/amd64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M5/amd64/debian/entrypoint.sh
+++ b/2.4.0.M5/amd64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M5/arm64/alpine/entrypoint.sh
+++ b/2.4.0.M5/arm64/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M5/arm64/debian/entrypoint.sh
+++ b/2.4.0.M5/arm64/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M5/armhf/alpine/entrypoint.sh
+++ b/2.4.0.M5/armhf/alpine/entrypoint.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/2.4.0.M5/armhf/debian/entrypoint.sh
+++ b/2.4.0.M5/armhf/debian/entrypoint.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/entrypoint-alpine.sh
+++ b/entrypoint-alpine.sh
@@ -113,7 +113,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done

--- a/entrypoint-debian.sh
+++ b/entrypoint-debian.sh
@@ -124,7 +124,7 @@ esac
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
-    for script in $(find /etc/cont-init.d -type f | grep -v \~)
+    for script in $(find /etc/cont-init.d -type f | grep -v \~ | sort)
     do
         . ${script}
     done


### PR DESCRIPTION
It is always beneficial to have defined order on script execution. For example, one script setting up a SSH host key, and the next opening up the SSH port to the outside.

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/205)
<!-- Reviewable:end -->
