### PR TITLE
Use TERM=dumb only as fallback

### DIFF
--- a/1.8.3/amd64/alpine/Dockerfile
+++ b/1.8.3/amd64/alpine/Dockerfile
@@ -72,7 +72,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
     rm /tmp/openhab.zip && \
     cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons

--- a/1.8.3/amd64/debian/Dockerfile
+++ b/1.8.3/amd64/debian/Dockerfile
@@ -77,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
     rm /tmp/openhab.zip && \
     cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons

--- a/1.8.3/arm64/alpine/Dockerfile
+++ b/1.8.3/arm64/alpine/Dockerfile
@@ -72,7 +72,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
     rm /tmp/openhab.zip && \
     cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons

--- a/1.8.3/arm64/debian/Dockerfile
+++ b/1.8.3/arm64/debian/Dockerfile
@@ -82,7 +82,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
     rm /tmp/openhab.zip && \
     cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons

--- a/1.8.3/armhf/alpine/Dockerfile
+++ b/1.8.3/armhf/alpine/Dockerfile
@@ -72,7 +72,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
     rm /tmp/openhab.zip && \
     cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons

--- a/1.8.3/armhf/debian/Dockerfile
+++ b/1.8.3/armhf/debian/Dockerfile
@@ -77,7 +77,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
     rm /tmp/openhab.zip && \
     cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/configurations ${APPDIR}/addons

--- a/2.0.0/amd64/alpine/Dockerfile
+++ b/2.0.0/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.0.0/amd64/debian/Dockerfile
+++ b/2.0.0/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.0.0/arm64/alpine/Dockerfile
+++ b/2.0.0/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.0.0/arm64/debian/Dockerfile
+++ b/2.0.0/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.0.0/armhf/alpine/Dockerfile
+++ b/2.0.0/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.0.0/armhf/debian/Dockerfile
+++ b/2.0.0/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.1.0/amd64/alpine/Dockerfile
+++ b/2.1.0/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.1.0/amd64/debian/Dockerfile
+++ b/2.1.0/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.1.0/arm64/alpine/Dockerfile
+++ b/2.1.0/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.1.0/arm64/debian/Dockerfile
+++ b/2.1.0/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.1.0/armhf/alpine/Dockerfile
+++ b/2.1.0/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.1.0/armhf/debian/Dockerfile
+++ b/2.1.0/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.2.0/amd64/alpine/Dockerfile
+++ b/2.2.0/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.2.0/amd64/debian/Dockerfile
+++ b/2.2.0/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.2.0/arm64/alpine/Dockerfile
+++ b/2.2.0/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.2.0/arm64/debian/Dockerfile
+++ b/2.2.0/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.2.0/armhf/alpine/Dockerfile
+++ b/2.2.0/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.2.0/armhf/debian/Dockerfile
+++ b/2.2.0/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.3.0/amd64/alpine/Dockerfile
+++ b/2.3.0/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.3.0/amd64/debian/Dockerfile
+++ b/2.3.0/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.3.0/arm64/alpine/Dockerfile
+++ b/2.3.0/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.3.0/arm64/debian/Dockerfile
+++ b/2.3.0/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.3.0/armhf/alpine/Dockerfile
+++ b/2.3.0/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.3.0/armhf/debian/Dockerfile
+++ b/2.3.0/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0-snapshot/amd64/alpine/Dockerfile
+++ b/2.4.0-snapshot/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0-snapshot/amd64/debian/Dockerfile
+++ b/2.4.0-snapshot/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0-snapshot/arm64/alpine/Dockerfile
+++ b/2.4.0-snapshot/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0-snapshot/arm64/debian/Dockerfile
+++ b/2.4.0-snapshot/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0-snapshot/armhf/alpine/Dockerfile
+++ b/2.4.0-snapshot/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0-snapshot/armhf/debian/Dockerfile
+++ b/2.4.0-snapshot/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M3/amd64/alpine/Dockerfile
+++ b/2.4.0.M3/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M3/amd64/debian/Dockerfile
+++ b/2.4.0.M3/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M3/arm64/alpine/Dockerfile
+++ b/2.4.0.M3/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M3/arm64/debian/Dockerfile
+++ b/2.4.0.M3/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M3/armhf/alpine/Dockerfile
+++ b/2.4.0.M3/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M3/armhf/debian/Dockerfile
+++ b/2.4.0.M3/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M4/amd64/alpine/Dockerfile
+++ b/2.4.0.M4/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M4/amd64/debian/Dockerfile
+++ b/2.4.0.M4/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M4/arm64/alpine/Dockerfile
+++ b/2.4.0.M4/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M4/arm64/debian/Dockerfile
+++ b/2.4.0.M4/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M4/armhf/alpine/Dockerfile
+++ b/2.4.0.M4/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M4/armhf/debian/Dockerfile
+++ b/2.4.0.M4/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M5/amd64/alpine/Dockerfile
+++ b/2.4.0.M5/amd64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M5/amd64/debian/Dockerfile
+++ b/2.4.0.M5/amd64/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M5/arm64/alpine/Dockerfile
+++ b/2.4.0.M5/arm64/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M5/arm64/debian/Dockerfile
+++ b/2.4.0.M5/arm64/debian/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M5/armhf/alpine/Dockerfile
+++ b/2.4.0.M5/armhf/alpine/Dockerfile
@@ -76,7 +76,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/2.4.0.M5/armhf/debian/Dockerfile
+++ b/2.4.0.M5/armhf/debian/Dockerfile
@@ -81,7 +81,7 @@ RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
     touch "${APPDIR}/userdata/logs/openhab.log" && \
     cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
     cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-    echo "export TERM=dumb" | tee -a ~/.bashrc
+    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
 VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons

--- a/update-docker-files.sh
+++ b/update-docker-files.sh
@@ -233,7 +233,7 @@ print_openhab_install_oh1() {
 	    unzip -q /tmp/openhab.zip -d "${APPDIR}" && \
 	    rm /tmp/openhab.zip && \
 	    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
-	    echo "export TERM=dumb" | tee -a ~/.bashrc
+	    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 EOI
 }
@@ -250,7 +250,7 @@ print_openhab_install_oh2() {
 	    touch "${APPDIR}/userdata/logs/openhab.log" && \
 	    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
 	    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
-	    echo "export TERM=dumb" | tee -a ~/.bashrc
+	    echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 EOI
 }


### PR DESCRIPTION
Since Docker 1.13 (https://github.com/moby/moby/pull/26461) the TERM environment variable will be assigned a value when an interactive shell is used. So it's better to use `TERM=dumb` only as fallback when the variable has no value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/208)
<!-- Reviewable:end -->
