### PR TITLE
Fix broken 20-open-ssh-server link in README

### DIFF
--- a/contrib/cont-init.d/20-open-ssh-server
+++ b/contrib/cont-init.d/20-open-ssh-server
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+
+sed -i \
+    "s/\#org.apache.karaf.shell:sshHost\s*=.*/org.apache.karaf.shell:sshHost=0.0.0.0/g" \
+    /openhab/conf/services/runtime.cfg


### PR DESCRIPTION
Fixes the broken link in the [Open access from external hosts](https://github.com/openhab/openhab-docker#open-access-from-external-hosts) README section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/214)
<!-- Reviewable:end -->
