### PR TITLE
Allow for root operations in continuation scripts

### DIFF
--- a/1.8.3/alpine/entrypoint.sh
+++ b/1.8.3/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/1.8.3/debian/entrypoint.sh
+++ b/1.8.3/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.0.0/alpine/entrypoint.sh
+++ b/2.0.0/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.0.0/debian/entrypoint.sh
+++ b/2.0.0/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.1.0/alpine/entrypoint.sh
+++ b/2.1.0/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.1.0/debian/entrypoint.sh
+++ b/2.1.0/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.2.0/alpine/entrypoint.sh
+++ b/2.2.0/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.2.0/debian/entrypoint.sh
+++ b/2.2.0/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.3.0/alpine/entrypoint.sh
+++ b/2.3.0/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.3.0/debian/entrypoint.sh
+++ b/2.3.0/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.4.0/alpine/entrypoint.sh
+++ b/2.4.0/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.4.0/debian/entrypoint.sh
+++ b/2.4.0/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.5.0-snapshot/alpine/entrypoint.sh
+++ b/2.5.0-snapshot/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.5.0-snapshot/debian/entrypoint.sh
+++ b/2.5.0-snapshot/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.5.0.M1/alpine/entrypoint.sh
+++ b/2.5.0.M1/alpine/entrypoint.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/2.5.0.M1/debian/entrypoint.sh
+++ b/2.5.0.M1/debian/entrypoint.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/README.md
+++ b/README.md
@@ -496,6 +496,14 @@ fi
 ```
 
 
+### Give pcap permissions to the java process
+
+[50-setpcap-on-java](https://github.com/openhab/openhab-docker/blob/master/contrib/cont-init.d/50-setpcap-on-java)
+
+```shell
+setcap 'cap_net_bind_service=+ep' /usr/lib/java-8/bin/java
+```
+
 ## Contributing
 
 [Contribution guidelines](https://github.com/openhab/openhab-docker/blob/master/CONTRIBUTING.md)

--- a/entrypoint-alpine.sh
+++ b/entrypoint-alpine.sh
@@ -116,6 +116,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -125,8 +129,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY

--- a/entrypoint-debian.sh
+++ b/entrypoint-debian.sh
@@ -127,6 +127,10 @@ case ${OPENHAB_VERSION} in
     ;;
 esac
 
+# Set openhab folder permission
+chown -R openhab:openhab "${APPDIR}"
+sync
+
 # Run s6-style init continuation scripts if existent
 if [ -d /etc/cont-init.d ]
 then
@@ -136,8 +140,7 @@ then
     done
 fi
 
-# Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+# sync again after continuation scripts have been run
 sync
 
 # Use server mode with the default command when there is no pseudo-TTY


### PR DESCRIPTION
Run the continuation scripts after the first chown so users can run setpcap on the java binary.

See https://community.openhab.org/t/cannot-configure-openhab-docker-to-use-port-80/67376/8?u=hakan

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/227)
<!-- Reviewable:end -->
