### PR TITLE
Install missing libnss

### DIFF
--- a/1.8.3/alpine/Dockerfile-amd64
+++ b/1.8.3/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/1.8.3/alpine/Dockerfile-arm64
+++ b/1.8.3/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/1.8.3/alpine/Dockerfile-armhf
+++ b/1.8.3/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.0.0/alpine/Dockerfile-amd64
+++ b/2.0.0/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.0.0/alpine/Dockerfile-arm64
+++ b/2.0.0/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.0.0/alpine/Dockerfile-armhf
+++ b/2.0.0/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.1.0/alpine/Dockerfile-amd64
+++ b/2.1.0/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.1.0/alpine/Dockerfile-arm64
+++ b/2.1.0/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.1.0/alpine/Dockerfile-armhf
+++ b/2.1.0/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.2.0/alpine/Dockerfile-amd64
+++ b/2.2.0/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.2.0/alpine/Dockerfile-arm64
+++ b/2.2.0/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.2.0/alpine/Dockerfile-armhf
+++ b/2.2.0/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.3.0/alpine/Dockerfile-amd64
+++ b/2.3.0/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.3.0/alpine/Dockerfile-arm64
+++ b/2.3.0/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.3.0/alpine/Dockerfile-armhf
+++ b/2.3.0/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.4.0/alpine/Dockerfile-amd64
+++ b/2.4.0/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.4.0/alpine/Dockerfile-arm64
+++ b/2.4.0/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.4.0/alpine/Dockerfile-armhf
+++ b/2.4.0/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.5.0-snapshot/alpine/Dockerfile-amd64
+++ b/2.5.0-snapshot/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.5.0-snapshot/alpine/Dockerfile-arm64
+++ b/2.5.0-snapshot/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.5.0-snapshot/alpine/Dockerfile-armhf
+++ b/2.5.0-snapshot/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.5.0.M1/alpine/Dockerfile-amd64
+++ b/2.5.0.M1/alpine/Dockerfile-amd64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.5.0.M1/alpine/Dockerfile-arm64
+++ b/2.5.0.M1/alpine/Dockerfile-arm64
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/2.5.0.M1/alpine/Dockerfile-armhf
+++ b/2.5.0.M1/alpine/Dockerfile-armhf
@@ -54,6 +54,7 @@ RUN apk upgrade --no-cache && \
         curl \
         fontconfig \
         libpcap-dev \
+        nss \
         shadow \
         su-exec \
         tini \

--- a/update-docker-files.sh
+++ b/update-docker-files.sh
@@ -134,6 +134,7 @@ print_basepackages_alpine() {
 	        curl \
 	        fontconfig \
 	        libpcap-dev \
+	        nss \
 	        shadow \
 	        su-exec \
 	        tini \


### PR DESCRIPTION
The image fails to start with "java.io.FileNotFoundException: /usr/lib/libnss3.so"

See https://github.com/docker-library/openjdk/issues/289

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/230)
<!-- Reviewable:end -->
