### PR TITLE
Update debian to 10 (buster) and Zulu JDK to 1.8.0_222

### DIFF
--- a/1.8.3/alpine/Dockerfile-amd64
+++ b/1.8.3/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 

--- a/1.8.3/alpine/Dockerfile-arm64
+++ b/1.8.3/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 

--- a/1.8.3/alpine/Dockerfile-armhf
+++ b/1.8.3/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 

--- a/1.8.3/debian/Dockerfile-amd64
+++ b/1.8.3/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/1.8.3/debian/Dockerfile-arm64
+++ b/1.8.3/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/1.8.3/debian/Dockerfile-armhf
+++ b/1.8.3/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.0.0/alpine/Dockerfile-amd64
+++ b/2.0.0/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 

--- a/2.0.0/alpine/Dockerfile-arm64
+++ b/2.0.0/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 

--- a/2.0.0/alpine/Dockerfile-armhf
+++ b/2.0.0/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 

--- a/2.0.0/debian/Dockerfile-amd64
+++ b/2.0.0/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.0.0/debian/Dockerfile-arm64
+++ b/2.0.0/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.0.0/debian/Dockerfile-armhf
+++ b/2.0.0/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.1.0/alpine/Dockerfile-amd64
+++ b/2.1.0/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 

--- a/2.1.0/alpine/Dockerfile-arm64
+++ b/2.1.0/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 

--- a/2.1.0/alpine/Dockerfile-armhf
+++ b/2.1.0/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 

--- a/2.1.0/debian/Dockerfile-amd64
+++ b/2.1.0/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.1.0/debian/Dockerfile-arm64
+++ b/2.1.0/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.1.0/debian/Dockerfile-armhf
+++ b/2.1.0/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.2.0/alpine/Dockerfile-amd64
+++ b/2.2.0/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 

--- a/2.2.0/alpine/Dockerfile-arm64
+++ b/2.2.0/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 

--- a/2.2.0/alpine/Dockerfile-armhf
+++ b/2.2.0/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 

--- a/2.2.0/debian/Dockerfile-amd64
+++ b/2.2.0/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.2.0/debian/Dockerfile-arm64
+++ b/2.2.0/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.2.0/debian/Dockerfile-armhf
+++ b/2.2.0/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.3.0/alpine/Dockerfile-amd64
+++ b/2.3.0/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 

--- a/2.3.0/alpine/Dockerfile-arm64
+++ b/2.3.0/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 

--- a/2.3.0/alpine/Dockerfile-armhf
+++ b/2.3.0/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 

--- a/2.3.0/debian/Dockerfile-amd64
+++ b/2.3.0/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.3.0/debian/Dockerfile-arm64
+++ b/2.3.0/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.3.0/debian/Dockerfile-armhf
+++ b/2.3.0/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.4.0/alpine/Dockerfile-amd64
+++ b/2.4.0/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 

--- a/2.4.0/alpine/Dockerfile-arm64
+++ b/2.4.0/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 

--- a/2.4.0/alpine/Dockerfile-armhf
+++ b/2.4.0/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 

--- a/2.4.0/debian/Dockerfile-amd64
+++ b/2.4.0/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.4.0/debian/Dockerfile-arm64
+++ b/2.4.0/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.4.0/debian/Dockerfile-armhf
+++ b/2.4.0/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.5.0-snapshot/alpine/Dockerfile-amd64
+++ b/2.5.0-snapshot/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="2.5.0-snapshot"
 

--- a/2.5.0-snapshot/alpine/Dockerfile-arm64
+++ b/2.5.0-snapshot/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="2.5.0-snapshot"
 

--- a/2.5.0-snapshot/alpine/Dockerfile-armhf
+++ b/2.5.0-snapshot/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="2.5.0-snapshot"
 

--- a/2.5.0-snapshot/debian/Dockerfile-amd64
+++ b/2.5.0-snapshot/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="2.5.0-snapshot"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.5.0-snapshot/debian/Dockerfile-arm64
+++ b/2.5.0-snapshot/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="2.5.0-snapshot"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.5.0-snapshot/debian/Dockerfile-armhf
+++ b/2.5.0-snapshot/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="2.5.0-snapshot"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.5.0.M1/alpine/Dockerfile-amd64
+++ b/2.5.0.M1/alpine/Dockerfile-amd64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:amd64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/2.5.0.M1/openhab-2.5.0.M1.zip" \
     OPENHAB_VERSION="2.5.0.M1"
 

--- a/2.5.0.M1/alpine/Dockerfile-arm64
+++ b/2.5.0.M1/alpine/Dockerfile-arm64
@@ -10,7 +10,7 @@ FROM multiarch/alpine:arm64-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/2.5.0.M1/openhab-2.5.0.M1.zip" \
     OPENHAB_VERSION="2.5.0.M1"
 

--- a/2.5.0.M1/alpine/Dockerfile-armhf
+++ b/2.5.0.M1/alpine/Dockerfile-armhf
@@ -10,7 +10,7 @@ FROM multiarch/alpine:armhf-v3.9
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/2.5.0.M1/openhab-2.5.0.M1.zip" \
     OPENHAB_VERSION="2.5.0.M1"
 

--- a/2.5.0.M1/debian/Dockerfile-amd64
+++ b/2.5.0.M1/debian/Dockerfile-amd64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:amd64-stretch
+FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz" \
     OPENHAB_URL="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/2.5.0.M1/openhab-2.5.0.M1.zip" \
     OPENHAB_VERSION="2.5.0.M1"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.5.0.M1/debian/Dockerfile-arm64
+++ b/2.5.0.M1/debian/Dockerfile-arm64
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:arm64-stretch
+FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz" \
     OPENHAB_URL="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/2.5.0.M1/openhab-2.5.0.M1.zip" \
     OPENHAB_VERSION="2.5.0.M1"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/2.5.0.M1/debian/Dockerfile-armhf
+++ b/2.5.0.M1/debian/Dockerfile-armhf
@@ -6,11 +6,11 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/debian-debootstrap:armhf-stretch
+FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz" \
     OPENHAB_URL="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/2.5.0.M1/openhab-2.5.0.M1.zip" \
     OPENHAB_VERSION="2.5.0.M1"
 
@@ -57,15 +57,12 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        tini \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     ln -s -f /bin/true /usr/bin/chfn && \
-    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Newer Docker versions (1.10.0+) have multi-architecture support which allows for
 
 **Distributions:**
 
-* `debian` for Debian stretch (default when not specified in tag)
+* `debian` for Debian buster (default when not specified in tag)
 * `alpine` for Alpine 3.9
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).

--- a/update-docker-files.sh
+++ b/update-docker-files.sh
@@ -47,13 +47,13 @@ print_baseimage() {
 	# Set Java download based on architecture
 	case $arch in
 	amd64)
-		java_url="https://cdn.azul.com/zulu/bin/zulu8.33.0.1-jdk8.0.192-linux_x64.tar.gz"
+		java_url="https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz"
 		;;
 	armhf)
-		java_url="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.134-jdk1.8.0_192-linux_aarch32hf.tar.gz"
+		java_url="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch32hf.tar.gz"
 		;;
 	arm64)
-		java_url="https://cdn.azul.com/zulu-embedded/bin/zulu8.33.0.135-jdk1.8.0_192-linux_aarch64.tar.gz"
+		java_url="https://cdn.azul.com/zulu-embedded/bin/zulu8.40.0.178-ca-jdk1.8.0_222-linux_aarch64.tar.gz"
 		;;
 	default)
 		java_url="error"
@@ -66,7 +66,7 @@ print_baseimage() {
 		base_image="alpine:$arch-v3.9"
 		;;
 	debian)
-		base_image="debian-debootstrap:$arch-stretch"
+		base_image="debian-debootstrap:$arch-buster"
 		;;
 	default)
 		base_image="error"
@@ -164,15 +164,12 @@ print_basepackages_debian() {
 	        locales \
 	        locales-all \
 	        netbase \
+	        tini \
 	        unzip \
 	        wget \
 	        zip && \
 	    chmod u+s /usr/sbin/arping && \
 	    ln -s -f /bin/true /usr/bin/chfn && \
-	    sed -i 's#stretch#buster#g' /etc/apt/sources.list && \
-	    apt-get update && \
-	    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tini && \
-	    sed -i 's#buster#stretch#g' /etc/apt/sources.list && \
 	    apt-get clean && \
 	    rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
* Updates the OS in the Debian container to Debian 10 (buster) which is the current stable Debian release (see [announcement](https://www.debian.org/News/2019/20190706))
* Updates the Zulu JDK inside the container to 1.8.0_222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/236)
<!-- Reviewable:end -->
