### PR TITLE
Update userdata using common openHAB update files

### DIFF
--- a/1.8.3/alpine/Dockerfile-amd64
+++ b/1.8.3/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -73,19 +77,20 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" && \
     rm /tmp/openhab.zip && \
-    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+VOLUME ${OPENHAB_HOME}/configurations ${OPENHAB_HOME}/addons
 
 # Expose HTTP and HTTPS ports
 EXPOSE 8080 8443
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.8.3/alpine/Dockerfile-arm64
+++ b/1.8.3/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -73,19 +77,20 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" && \
     rm /tmp/openhab.zip && \
-    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+VOLUME ${OPENHAB_HOME}/configurations ${OPENHAB_HOME}/addons
 
 # Expose HTTP and HTTPS ports
 EXPOSE 8080 8443
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.8.3/alpine/Dockerfile-armhf
+++ b/1.8.3/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -73,19 +77,20 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" && \
     rm /tmp/openhab.zip && \
-    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+VOLUME ${OPENHAB_HOME}/configurations ${OPENHAB_HOME}/addons
 
 # Expose HTTP and HTTPS ports
 EXPOSE 8080 8443
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.8.3/debian/Dockerfile-amd64
+++ b/1.8.3/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -77,19 +81,20 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" && \
     rm /tmp/openhab.zip && \
-    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+VOLUME ${OPENHAB_HOME}/configurations ${OPENHAB_HOME}/addons
 
 # Expose HTTP and HTTPS ports
 EXPOSE 8080 8443
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.8.3/debian/Dockerfile-arm64
+++ b/1.8.3/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -77,19 +81,20 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" && \
     rm /tmp/openhab.zip && \
-    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+VOLUME ${OPENHAB_HOME}/configurations ${OPENHAB_HOME}/addons
 
 # Expose HTTP and HTTPS ports
 EXPOSE 8080 8443
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.8.3/debian/Dockerfile-armhf
+++ b/1.8.3/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -77,19 +81,20 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" && \
     rm /tmp/openhab.zip && \
-    cp -a "${APPDIR}/configurations" "${APPDIR}/configurations.dist" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/configurations ${APPDIR}/addons
+VOLUME ${OPENHAB_HOME}/configurations ${OPENHAB_HOME}/addons
 
 # Expose HTTP and HTTPS ports
 EXPOSE 8080 8443
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.8.3/debian/entrypoint.sh
+++ b/1.8.3/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.0.0/alpine/Dockerfile-amd64
+++ b/2.0.0/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.0.0/alpine/Dockerfile-arm64
+++ b/2.0.0/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.0.0/alpine/Dockerfile-armhf
+++ b/2.0.0/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.0.0/alpine/update.sh
+++ b/2.0.0/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.0.0/debian/Dockerfile-amd64
+++ b/2.0.0/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.0.0/debian/Dockerfile-arm64
+++ b/2.0.0/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.0.0/debian/Dockerfile-armhf
+++ b/2.0.0/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.0.0/debian/entrypoint.sh
+++ b/2.0.0/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.0.0/debian/update.sh
+++ b/2.0.0/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.1.0/alpine/Dockerfile-amd64
+++ b/2.1.0/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.1.0/alpine/Dockerfile-arm64
+++ b/2.1.0/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.1.0/alpine/Dockerfile-armhf
+++ b/2.1.0/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.1.0/alpine/update.sh
+++ b/2.1.0/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.1.0/debian/Dockerfile-amd64
+++ b/2.1.0/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.1.0/debian/Dockerfile-arm64
+++ b/2.1.0/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.1.0/debian/Dockerfile-armhf
+++ b/2.1.0/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS and Console ports
 EXPOSE 8080 8443 8101
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.1.0/debian/entrypoint.sh
+++ b/2.1.0/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.1.0/debian/update.sh
+++ b/2.1.0/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.2.0/alpine/Dockerfile-amd64
+++ b/2.2.0/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.2.0/alpine/Dockerfile-arm64
+++ b/2.2.0/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.2.0/alpine/Dockerfile-armhf
+++ b/2.2.0/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.2.0/alpine/update.sh
+++ b/2.2.0/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.2.0/debian/Dockerfile-amd64
+++ b/2.2.0/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.2.0/debian/Dockerfile-arm64
+++ b/2.2.0/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.2.0/debian/Dockerfile-armhf
+++ b/2.2.0/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.2.0/debian/entrypoint.sh
+++ b/2.2.0/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.2.0/debian/update.sh
+++ b/2.2.0/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.3.0/alpine/Dockerfile-amd64
+++ b/2.3.0/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.3.0/alpine/Dockerfile-arm64
+++ b/2.3.0/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.3.0/alpine/Dockerfile-armhf
+++ b/2.3.0/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.3.0/alpine/update.sh
+++ b/2.3.0/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.3.0/debian/Dockerfile-amd64
+++ b/2.3.0/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.3.0/debian/Dockerfile-arm64
+++ b/2.3.0/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.3.0/debian/Dockerfile-armhf
+++ b/2.3.0/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.3.0/debian/entrypoint.sh
+++ b/2.3.0/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.3.0/debian/update.sh
+++ b/2.3.0/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.4.0/alpine/Dockerfile-amd64
+++ b/2.4.0/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4.0/alpine/Dockerfile-arm64
+++ b/2.4.0/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4.0/alpine/Dockerfile-armhf
+++ b/2.4.0/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4.0/alpine/update.sh
+++ b/2.4.0/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.4.0/debian/Dockerfile-amd64
+++ b/2.4.0/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4.0/debian/Dockerfile-arm64
+++ b/2.4.0/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4.0/debian/Dockerfile-armhf
+++ b/2.4.0/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.4.0/debian/entrypoint.sh
+++ b/2.4.0/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.4.0/debian/update.sh
+++ b/2.4.0/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.5.0-snapshot/alpine/Dockerfile-amd64
+++ b/2.5.0-snapshot/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0-snapshot/alpine/Dockerfile-arm64
+++ b/2.5.0-snapshot/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0-snapshot/alpine/Dockerfile-armhf
+++ b/2.5.0-snapshot/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0-snapshot/alpine/update.sh
+++ b/2.5.0-snapshot/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.5.0-snapshot/debian/Dockerfile-amd64
+++ b/2.5.0-snapshot/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0-snapshot/debian/Dockerfile-arm64
+++ b/2.5.0-snapshot/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0-snapshot/debian/Dockerfile-armhf
+++ b/2.5.0-snapshot/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0-snapshot/debian/entrypoint.sh
+++ b/2.5.0-snapshot/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.5.0-snapshot/debian/update.sh
+++ b/2.5.0-snapshot/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.5.0.M1/alpine/Dockerfile-amd64
+++ b/2.5.0.M1/alpine/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0.M1/alpine/Dockerfile-arm64
+++ b/2.5.0.M1/alpine/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0.M1/alpine/Dockerfile-armhf
+++ b/2.5.0.M1/alpine/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -74,22 +78,26 @@ RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0.M1/alpine/update.sh
+++ b/2.5.0.M1/alpine/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/2.5.0.M1/debian/Dockerfile-amd64
+++ b/2.5.0.M1/debian/Dockerfile-amd64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0.M1/debian/Dockerfile-arm64
+++ b/2.5.0.M1/debian/Dockerfile-arm64
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0.M1/debian/Dockerfile-armhf
+++ b/2.5.0.M1/debian/Dockerfile-armhf
@@ -16,15 +16,19 @@ ENV \
 
 # Set variables and locales
 ENV \
-    APPDIR="/openhab" \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
+    OPENHAB_BACKUPS="/openhab/userdata/backup" \
+    OPENHAB_CONF="/openhab/conf" \
+    OPENHAB_HOME="/openhab" \
     OPENHAB_HTTP_PORT="8080" \
-    OPENHAB_HTTPS_PORT="8443"
+    OPENHAB_HTTPS_PORT="8443" \
+    OPENHAB_LOGDIR="/openhab/userdata/logs" \
+    OPENHAB_USERDATA="/openhab/userdata"
 
 # Set arguments on build
 ARG BUILD_DATE
@@ -78,22 +82,26 @@ RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \
-    unzip -q /tmp/openhab.zip -d "${APPDIR}" -x "*.bat" && \
+    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
-    mkdir -p "${APPDIR}/userdata/logs" && \
-    touch "${APPDIR}/userdata/logs/openhab.log" && \
-    cp -a "${APPDIR}/userdata" "${APPDIR}/userdata.dist" && \
-    cp -a "${APPDIR}/conf" "${APPDIR}/conf.dist" && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \
+    if [ ! -f "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" ]; then wget -nv -O "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst" "https://raw.githubusercontent.com/openhab/openhab-distro/2.4.0/distributions/openhab/src/main/resources/bin/userdata_sysfiles.lst"; fi && \
+    mkdir -p "${OPENHAB_LOGDIR}" && \
+    touch "${OPENHAB_LOGDIR}/openhab.log" && \
+    mkdir -p "${OPENHAB_HOME}/dist" && \
+    cp -a "${OPENHAB_CONF}" "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist" && \
     echo 'export TERM=${TERM:=dumb}' | tee -a ~/.bashrc
+COPY update.sh ${OPENHAB_HOME}/runtime/bin/update
+RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
 # Expose volume with configuration and userdata dir
-VOLUME ${APPDIR}/conf ${APPDIR}/userdata ${APPDIR}/addons
+VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
 # Set working directory and entrypoint
-WORKDIR ${APPDIR}
+WORKDIR ${OPENHAB_HOME}
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/2.5.0.M1/debian/entrypoint.sh
+++ b/2.5.0.M1/debian/entrypoint.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/2.5.0.M1/debian/update.sh
+++ b/2.5.0.M1/debian/update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""

--- a/README.md
+++ b/README.md
@@ -382,22 +382,26 @@ The following addons are known to depend on the unlimited cryptographic strength
 ## Upgrading
 
 Upgrading OH requires changes to the user mapped in userdata folder.
-The container will perform these steps automatically when it detects that the `userdata/etc/version.properties` is different from the version in `userdata.dist/etc/version.properties` in the Docker image.
-The steps performed are:
+The container will perform these steps automatically when it detects that the `userdata/etc/version.properties` is different from the version in `dist/userdata/etc/version.properties` in the Docker image.
 
+The steps performed are:
 * Create a `userdata/backup` folder if one does not exist.
 * Create a full backup of userdata as a dated tar file saved to `userdata/backup`. The `userdata/backup` folder is excluded from this backup.
-* Copy over the relevant files from `userdata.dist/etc` to `userdata/etc`.
+* Show update notes and warnings.
+* Execute update pre/post commands.
+* Copy userdata system files from `dist/userdata/etc` to `userdata/etc`.
+* Update KAR files in `addons`.
 * Delete the contents of `userdata/cache` and `userdata/tmp`.
 
 The steps performed are the same as those performed by running the upgrade script that comes with OH, except the backup is performed differently and the latest openHAB runtime is not downloaded.
+All messages shown during the update are also logged to `userdata/logs/update.log`.
 
 ## Building the images
 
-Checkout the GitHub repository, change to a directory with a Dockerfile and then run these commands:
+Checkout the GitHub repository, change to a directory containing Dockerfiles (e.g. `2.4.0/debian`) and then run these commands to build and run a amd64 image:
 
 ```shell
-$ docker build -t openhab/openhab .
+$ docker build -f Dockerfile-amd64 -t openhab/openhab .
 $ docker run openhab/openhab
 ```
 
@@ -510,5 +514,4 @@ setcap 'cap_net_bind_service=+ep' /usr/lib/java-8/bin/java
 
 ## License
 
-When not explicitly set, files are placed under [![EPL-2.0 license](https://img.shields.io/badge/license-EPL--2.0-blue.svg)](https://raw.githubusercontent.com/openhab/openhab-docker/master/LICENSE).
-
+When not explicitly set, files are placed under [![EPL-2.0 license](https://img.shields.io/badge/license-EPL--2.0-blue.svg)](https://raw.githubusercontent.com/openhab/openhab-docker/master/LICENSE)

--- a/entrypoint-debian.sh
+++ b/entrypoint-debian.sh
@@ -14,11 +14,11 @@ fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart
 # See: https://github.com/openhab/openhab-docker/issues/99
-rm -f /openhab/runtime/instances/instance.properties
+rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
 # The instance.properties file in openHAB 2.x is installed in the tmp
 # directory
-rm -f /openhab/userdata/tmp/instances/instance.properties
+rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems
 # Container base image puts dialout on group id 20, uucp on id 10
@@ -36,7 +36,7 @@ if ! id -u openhab >/dev/null 2>&1; then
     groupmod --new-name openhab $group_name
   fi
   echo "Create user openhab with id ${NEW_USER_ID}"
-  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${APPDIR}" --gid $NEW_GROUP_ID openhab
+  adduser -u $NEW_USER_ID --disabled-password --gecos '' --home "${OPENHAB_HOME}" --gid $NEW_GROUP_ID openhab
   groupadd -g 14 uucp2
   groupadd -g 16 dialout2
   groupadd -g 18 dialout3
@@ -51,75 +51,38 @@ if ! id -u openhab >/dev/null 2>&1; then
   adduser openhab gpio
 fi
 
-# Copy initial files to host volume
+initialize_volume() {
+  volume="$1"
+  source="$2"
+
+  if [ -z "$(ls -A "$volume")" ]; then
+    echo "Initializing empty volume ${volume} ..."
+    cp -av "${source}/." "${volume}/"
+  fi
+}
+
+# Initialize empty volumes and update userdata
 case ${OPENHAB_VERSION} in
   1.*)
-      if [ -z "$(ls -A "${APPDIR}/configurations")" ]; then
-        # Copy userdata dir for openHAB 1.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/configurations.dist/." "${APPDIR}/configurations/"
-      fi
+      initialize_volume "${OPENHAB_HOME}/configurations" "${OPENHAB_HOME}/dist/configurations"
     ;;
   2.*)
-      # Initialize empty host volumes
-      if [ -z "$(ls -A "${APPDIR}/userdata")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No userdata found... initializing."
-        cp -av "${APPDIR}/userdata.dist/." "${APPDIR}/userdata/"
-      fi
+      initialize_volume "${OPENHAB_CONF}" "${OPENHAB_HOME}/dist/conf"
+      initialize_volume "${OPENHAB_USERDATA}" "${OPENHAB_HOME}/dist/userdata"
 
-      # Upgrade userdata if versions do not match
-      if [ ! -z $(cmp "${APPDIR}/userdata/etc/version.properties" "${APPDIR}/userdata.dist/etc/version.properties") ]; then
-        echo "Image and userdata versions differ! Starting an upgrade."
+      # Update userdata if versions do not match
+      if [ ! -z $(cmp "${OPENHAB_USERDATA}/etc/version.properties" "${OPENHAB_HOME}/dist/userdata/etc/version.properties") ]; then
+        echo "Image and userdata versions differ! Starting an upgrade." | tee "${OPENHAB_LOGDIR}/update.log"
 
         # Make a backup of userdata
-        backupFile=userdata-$(date +"%FT%H-%M-%S").tar
-        if [ ! -d "${APPDIR}/userdata/backup" ]; then
-          mkdir "${APPDIR}/userdata/backup"
+        backup_file=userdata-$(date +"%FT%H-%M-%S").tar
+        if [ ! -d "${OPENHAB_BACKUPS}" ]; then
+          mkdir "${OPENHAB_BACKUPS}"
         fi
-        tar --exclude="${APPDIR}/userdata/backup" -c -f "${APPDIR}/userdata/backup/${backupFile}" "${APPDIR}/userdata"
-        echo "You can find backup of userdata in ${APPDIR}/userdata/backup/${backupFile}"
+        tar --exclude="${OPENHAB_BACKUPS}" -c -f "${OPENHAB_BACKUPS}/${backup_file}" "${OPENHAB_USERDATA}"
+        echo "You can find backup of userdata in ${OPENHAB_BACKUPS}/${backup_file}" | tee -a "${OPENHAB_LOGDIR}/update.log"
 
-        # Copy over the updated files
-        cp "${APPDIR}/userdata.dist/etc/all.policy" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/branding-ssh.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/config.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/custom.properties" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/custom.system.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/custom.system.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/distribution.info" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/jre.properties" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.apache.karaf"* "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/org.ops4j.pax.url.mvn.cfg" "${APPDIR}/userdata/etc/"
-        if [ -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          cp "${APPDIR}/userdata.dist/etc/overrides.properties" "${APPDIR}/userdata/etc/"
-        fi
-        cp "${APPDIR}/userdata.dist/etc/profile.cfg" "${APPDIR}/userdata/etc/"
-        cp "${APPDIR}/userdata.dist/etc/startup.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/system.properties" "${APPDIR}/userdata/etc"
-        cp "${APPDIR}/userdata.dist/etc/version.properties" "${APPDIR}/userdata/etc/"
-        echo "Replaced files in userdata/etc with newer versions"
-
-        # Remove necessary files after installation
-        rm -rf "${APPDIR}/userdata/etc/org.openhab.addons.cfg"
-        if [ ! -f "${APPDIR}/userdata.dist/etc/overrides.properties" ]; then
-          rm -rf "${APPDIR}/userdata/etc/overrides.properties"
-        fi
-
-        # Clear the cache and tmp
-        rm -rf "${APPDIR}/userdata/cache"
-        rm -rf "${APPDIR}/userdata/tmp"
-        mkdir "${APPDIR}/userdata/cache"
-        mkdir "${APPDIR}/userdata/tmp"
-        echo "Cleared the cache and tmp"
-      fi
-
-      if [ -z "$(ls -A "${APPDIR}/conf")" ]; then
-        # Copy userdata dir for openHAB 2.x
-        echo "No configuration found... initializing."
-        cp -av "${APPDIR}/conf.dist/." "${APPDIR}/conf/"
+        exec "${OPENHAB_HOME}/runtime/bin/update" 2>&1 | tee -a "${OPENHAB_LOGDIR}/update.log"
       fi
     ;;
   *)
@@ -128,7 +91,7 @@ case ${OPENHAB_VERSION} in
 esac
 
 # Set openhab folder permission
-chown -R openhab:openhab "${APPDIR}"
+chown -R openhab:openhab "${OPENHAB_HOME}"
 sync
 
 # Run s6-style init continuation scripts if existent

--- a/openhab2-update.sh
+++ b/openhab2-update.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+
+setup() {
+  # Ask to run as root to prevent us from running sudo in this script.
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Please run this script as root! (e.g. use sudo)" >&2
+    exit 1
+  fi
+
+  current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
+  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
+
+  # Choose bintray for releases, jenkins for snapshots and artifactory for milestones or release candidates.
+  if test "${oh_version#*-SNAPSHOT}" != "${oh_version}"; then
+    addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons/target/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab-addons-legacy/target/openhab-addons-legacy-${oh_version}.kar"
+  elif [ "${oh_version}" = "$current_version" ]; then
+    echo "You are already on openHAB $current_version" >&2
+    exit 1
+  elif [ -n "$milestone_version" ]; then
+    addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons/${oh_version}/openhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab-addons-legacy/${oh_version}/openhab-addons-legacy-${oh_version}.kar"
+  else
+    addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons%2F${oh_version}%2Fopenhab-addons-${oh_version}.kar"
+    legacy_addons_download_location="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab-addons-legacy%2F${oh_version}%2Fopenhab-addons-legacy-${oh_version}.kar"
+  fi
+}
+
+run_command() {
+    string="$1"
+    string="$(echo "$string" | sed "s:\$OPENHAB_USERDATA:${OPENHAB_USERDATA:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_CONF:${OPENHAB_CONF:?}:g")"
+    string="$(echo "$string" | sed "s:\$OPENHAB_HOME:${OPENHAB_HOME:?}:g")"
+
+    command="$(echo "$string" | awk -F';' '{print $1}')"
+    param1="$(echo "$string" | awk -F';' '{print $2}')"
+    param2="$(echo "$string" | awk -F';' '{print $3}')"
+    param3="$(echo "$string" | awk -F';' '{print $4}')"
+
+    case $command in
+    'DEFAULT')
+      # Just rename the file, the update process adds back the new version
+      echo "  Adding '.bak' to $param1"
+      mv "$param1" "$param1.bak"
+    ;;
+    'DELETE')
+      # We should be strict and specific here, i.e only delete one file.
+      if [ -f "$param1" ]; then
+        echo "  Deleting File: $param1"
+        rm -f "$param1"
+      fi
+    ;;
+    'DELETEDIR')
+      # We should be strict and specific here, i.e only delete one directory.
+      if [ -d "$param1" ]; then
+        echo "  Deleting Directory: $param1"
+        rm -rf "$param1"
+      fi
+    ;;
+    'MOVE')
+      echo "  Moving:   From $param1 to $param2"
+      mv "$param1" "$param2"
+    ;;
+    'REPLACE')
+      # Avoid error if file does not exist
+      if [ -f "$param3" ]; then
+        echo "  Replacing: String $param1 to $param2 in file $param3"
+        sed -i "s:$param1:$param2:g" "$param3"
+      fi
+    ;;
+    'NOTE')  printf '  \033[32mNote:\033[m     %s\n' "$param1";;
+    'ALERT') printf '  \033[31mWarning:\033[m  %s\n' "$param1";;
+    esac
+}
+
+get_version_number() {
+  first_part="$(echo "$1" | awk -F'.' '{print $1}')"
+  second_part="$(echo "$1" | awk -F'.' '{print $2}')"
+  third_part="$(echo "$1" | awk -F'.' '{print $3}')"
+  third_part="${third_part%%-*}"
+  echo $((first_part*10000+second_part*100+third_part))
+}
+
+scan_versioning_list() {
+  section="$1"
+  version_message="$2"
+  in_section=false
+  in_new_version=false
+
+  # Read the file line by line.
+  while IFS= read -r line
+  do
+    case $line in
+    '')
+      continue
+    ;;
+    # Flag to run the relevant [[section]] only.
+    "[[$section]]")
+      in_section=true
+    ;;
+    # Stop reading the file if another [[section]] starts.
+    "[["*"]]")
+      if $in_section; then
+        break
+      fi
+    ;;
+    # Detect the [version] and execute the line if relevant.
+    '['*'.'*'.'*']')
+      if $in_section; then
+        line_version="$(echo "$line" | awk -F'[][]' '{print $2}')"
+        line_version_number=$(get_version_number "$line_version")
+        if [ "$current_version_number" -lt "$line_version_number" ]; then
+          in_new_version=true
+          echo ""
+          echo "$version_message $line_version:"
+        else
+          in_new_version=false
+        fi
+      fi
+    ;;
+    *)
+      if $in_section && $in_new_version; then
+        run_command "$line"
+      fi
+    ;;
+    esac
+  done < "${OPENHAB_HOME}/runtime/bin/update.lst"
+}
+
+echo ""
+echo "################################################"
+echo "       openHAB 2.x.x Docker update script       "
+echo "################################################"
+echo ""
+
+# Run the initialisation functions defined above
+setup
+
+current_version_number=$(get_version_number "$current_version")
+case $current_version in
+  *"-"* | *"."*"."*"."*) current_version_number=$((current_version_number-1));;
+esac
+
+# Notify the user of important changes first
+echo "The script will attempt to update openHAB to version ${oh_version}"
+printf 'Please read the following \033[32mnotes\033[m and \033[31mwarnings\033[m:\n'
+scan_versioning_list "MSG" "Important notes for version"
+echo ""
+
+# Perform version specific pre-update commands
+scan_versioning_list "PRE" "Performing pre-update tasks for version"
+
+echo "Replacing userdata system files with newer versions..."
+while IFS= read -r file_name
+do
+  full_path="${OPENHAB_HOME}/dist/userdata/etc/${file_name}"
+  if [ -f "$full_path" ]; then
+    cp "$full_path" "${OPENHAB_USERDATA}/etc/"
+  fi
+done < "${OPENHAB_HOME}/runtime/bin/userdata_sysfiles.lst"
+
+# Clearing the cache and tmp folders is necessary for upgrade.
+echo "Clearing cache..."
+rm -rf "${OPENHAB_USERDATA:?}/cache"
+rm -rf "${OPENHAB_USERDATA:?}/tmp"
+
+# Perform version specific post-update commands
+scan_versioning_list "POST" "Performing post-update tasks for version"
+
+# If there's an existing addons file, we need to replace it with the correct version.
+addons_file="${OPENHAB_HOME}/addons/openhab-addons-${current_version}.kar"
+if [ -f "$addons_file" ]; then
+  echo "Found an openHAB addons file, replacing with new version..."
+  rm -f "${addons_file:?}"
+  curl -Lf# "$addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-${oh_version}.kar" || {
+      echo "Download of addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+
+# Do the same for the legacy addons file.
+legacy_addons_file="${OPENHAB_HOME}/addons/openhab-addons-legacy-${current_version}.kar"
+if [ -f "$legacy_addons_file" ]; then
+  echo "Found an openHAB legacy addons file, replacing with new version..."
+  rm -f "${legacy_addons_file:?}"
+  curl -Lf# "$legacy_addons_download_location" -o "${OPENHAB_HOME}/addons/openhab-addons-legacy-${oh_version}.kar" || {
+      echo "Download of legacy addons file failed, please find it on the openHAB website (www.openhab.org)" >&2
+  }
+fi
+echo ""
+
+echo ""
+echo "SUCCESS: openHAB updated from ${current_version} to ${oh_version}"
+echo ""


### PR DESCRIPTION
Reworks the update process to update the userdata in the container using the `update.lst` and `userdata_sysfiles.lst` files (provided by openhab-distro).
The update script has been modified for use in the container.

This adds the following new functionality when updating between versions:
* show update notes and warnings during the update (based on `update.lst`)
* execute the update pre/post commands (based on `update.lst`)
* replace userdata system files with newer versions (based on `userdata_sysfiles.lst`)
* update KAR files in addons dir by downloading newer versions
* log the update output in update.log

Other improvements are:
* declare and use common openHAB environment variables in scripts (OPENHAB_BACKUPS, OPENHAB_CONF, OPENHAB_HOME, OPENHAB_LOGDIR, OPENHAB_USERDATA)
* initialize empty volumes using a reusable method
* move all default volume data into the "dist" directory
* remove Windows PowerShell scripts from container images

---

I've tested many upgrade scenarios with the Debian and Alpine images. This change also allows for updating the classnames of rules created in Paper UI (https://github.com/openhab/openhab-core/issues/674) for 2.5.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/239)
<!-- Reviewable:end -->
