### PR TITLE
Fix missing setcap/pgrep commands

### DIFF
--- a/1.8.3/alpine/Dockerfile-amd64
+++ b/1.8.3/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/1.8.3/alpine/Dockerfile-arm64
+++ b/1.8.3/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/1.8.3/alpine/Dockerfile-armhf
+++ b/1.8.3/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/1.8.3/debian/Dockerfile-amd64
+++ b/1.8.3/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/1.8.3/debian/Dockerfile-arm64
+++ b/1.8.3/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/1.8.3/debian/Dockerfile-armhf
+++ b/1.8.3/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.0.0/alpine/Dockerfile-amd64
+++ b/2.0.0/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.0.0/alpine/Dockerfile-arm64
+++ b/2.0.0/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.0.0/alpine/Dockerfile-armhf
+++ b/2.0.0/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.0.0/debian/Dockerfile-amd64
+++ b/2.0.0/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.0.0/debian/Dockerfile-arm64
+++ b/2.0.0/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.0.0/debian/Dockerfile-armhf
+++ b/2.0.0/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.1.0/alpine/Dockerfile-amd64
+++ b/2.1.0/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.1.0/alpine/Dockerfile-arm64
+++ b/2.1.0/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.1.0/alpine/Dockerfile-armhf
+++ b/2.1.0/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.1.0/debian/Dockerfile-amd64
+++ b/2.1.0/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.1.0/debian/Dockerfile-arm64
+++ b/2.1.0/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.1.0/debian/Dockerfile-armhf
+++ b/2.1.0/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.2.0/alpine/Dockerfile-amd64
+++ b/2.2.0/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.2.0/alpine/Dockerfile-arm64
+++ b/2.2.0/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.2.0/alpine/Dockerfile-armhf
+++ b/2.2.0/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.2.0/debian/Dockerfile-amd64
+++ b/2.2.0/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.2.0/debian/Dockerfile-arm64
+++ b/2.2.0/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.2.0/debian/Dockerfile-armhf
+++ b/2.2.0/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.3.0/alpine/Dockerfile-amd64
+++ b/2.3.0/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.3.0/alpine/Dockerfile-arm64
+++ b/2.3.0/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.3.0/alpine/Dockerfile-armhf
+++ b/2.3.0/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.3.0/debian/Dockerfile-amd64
+++ b/2.3.0/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.3.0/debian/Dockerfile-arm64
+++ b/2.3.0/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.3.0/debian/Dockerfile-armhf
+++ b/2.3.0/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.4.0/alpine/Dockerfile-amd64
+++ b/2.4.0/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.4.0/alpine/Dockerfile-arm64
+++ b/2.4.0/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.4.0/alpine/Dockerfile-armhf
+++ b/2.4.0/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.4.0/debian/Dockerfile-amd64
+++ b/2.4.0/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.4.0/debian/Dockerfile-arm64
+++ b/2.4.0/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.4.0/debian/Dockerfile-armhf
+++ b/2.4.0/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0-snapshot/alpine/Dockerfile-amd64
+++ b/2.5.0-snapshot/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0-snapshot/alpine/Dockerfile-arm64
+++ b/2.5.0-snapshot/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0-snapshot/alpine/Dockerfile-armhf
+++ b/2.5.0-snapshot/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0-snapshot/debian/Dockerfile-amd64
+++ b/2.5.0-snapshot/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0-snapshot/debian/Dockerfile-arm64
+++ b/2.5.0-snapshot/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0-snapshot/debian/Dockerfile-armhf
+++ b/2.5.0-snapshot/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M2/alpine/Dockerfile-amd64
+++ b/2.5.0.M2/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M2/alpine/Dockerfile-arm64
+++ b/2.5.0.M2/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M2/alpine/Dockerfile-armhf
+++ b/2.5.0.M2/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M2/debian/Dockerfile-amd64
+++ b/2.5.0.M2/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M2/debian/Dockerfile-arm64
+++ b/2.5.0.M2/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M2/debian/Dockerfile-armhf
+++ b/2.5.0.M2/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M3/alpine/Dockerfile-amd64
+++ b/2.5.0.M3/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M3/alpine/Dockerfile-arm64
+++ b/2.5.0.M3/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M3/alpine/Dockerfile-armhf
+++ b/2.5.0.M3/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M3/debian/Dockerfile-amd64
+++ b/2.5.0.M3/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M3/debian/Dockerfile-arm64
+++ b/2.5.0.M3/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M3/debian/Dockerfile-armhf
+++ b/2.5.0.M3/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M4/alpine/Dockerfile-amd64
+++ b/2.5.0.M4/alpine/Dockerfile-amd64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M4/alpine/Dockerfile-arm64
+++ b/2.5.0.M4/alpine/Dockerfile-arm64
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M4/alpine/Dockerfile-armhf
+++ b/2.5.0.M4/alpine/Dockerfile-armhf
@@ -59,7 +59,7 @@ RUN apk upgrade --no-cache && \
         ca-certificates \
         curl \
         fontconfig \
-        libpcap-dev \
+        libcap \
         nss \
         shadow \
         su-exec \

--- a/2.5.0.M4/debian/Dockerfile-amd64
+++ b/2.5.0.M4/debian/Dockerfile-amd64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M4/debian/Dockerfile-arm64
+++ b/2.5.0.M4/debian/Dockerfile-arm64
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/2.5.0.M4/debian/Dockerfile-armhf
+++ b/2.5.0.M4/debian/Dockerfile-armhf
@@ -59,10 +59,11 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
-        libpcap-dev \
+        libcap2-bin \
         locales \
         locales-all \
         netbase \
+        procps \
         tini \
         unzip \
         wget \

--- a/update-docker-files.sh
+++ b/update-docker-files.sh
@@ -139,7 +139,7 @@ print_basepackages_alpine() {
 	        ca-certificates \
 	        curl \
 	        fontconfig \
-	        libpcap-dev \
+	        libcap \
 	        nss \
 	        shadow \
 	        su-exec \
@@ -166,10 +166,11 @@ print_basepackages_debian() {
 	        curl \
 	        fontconfig \
 	        gosu \
-	        libpcap-dev \
+	        libcap2-bin \
 	        locales \
 	        locales-all \
 	        netbase \
+	        procps \
 	        tini \
 	        unzip \
 	        wget \


### PR DESCRIPTION
Fixes #246
Fixes #252

---

The `pgrep` command already worked on Alpine so there was no need for adding `procps` in that image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/254)
<!-- Reviewable:end -->
