### PR TITLE
Use Java 11 in OH3 images and upgrade to Alpine v3.11

### DIFF
--- a/1.8.3/alpine/Dockerfile-amd64
+++ b/1.8.3/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \

--- a/1.8.3/alpine/Dockerfile-arm64
+++ b/1.8.3/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \

--- a/1.8.3/alpine/Dockerfile-armhf
+++ b/1.8.3/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 RUN wget -nv -O /tmp/openhab.zip "${OPENHAB_URL}" && \

--- a/1.8.3/alpine/entrypoint.sh
+++ b/1.8.3/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/1.8.3/debian/Dockerfile-amd64
+++ b/1.8.3/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/1.8.3/debian/Dockerfile-arm64
+++ b/1.8.3/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/1.8.3/debian/Dockerfile-armhf
+++ b/1.8.3/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/artifact/download/openhab/bin/distribution-1.8.3-runtime.zip" \
     OPENHAB_VERSION="1.8.3"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/1.8.3/debian/entrypoint.sh
+++ b/1.8.3/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.0.0/alpine/Dockerfile-amd64
+++ b/2.0.0/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.0.0/alpine/Dockerfile-arm64
+++ b/2.0.0/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.0.0/alpine/Dockerfile-armhf
+++ b/2.0.0/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.0.0/alpine/entrypoint.sh
+++ b/2.0.0/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.0.0/debian/Dockerfile-amd64
+++ b/2.0.0/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.0.0/debian/Dockerfile-arm64
+++ b/2.0.0/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.0.0/debian/Dockerfile-armhf
+++ b/2.0.0/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.0.0%2Fopenhab-2.0.0.zip" \
     OPENHAB_VERSION="2.0.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.0.0/debian/entrypoint.sh
+++ b/2.0.0/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.1.0/alpine/Dockerfile-amd64
+++ b/2.1.0/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.1.0/alpine/Dockerfile-arm64
+++ b/2.1.0/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.1.0/alpine/Dockerfile-armhf
+++ b/2.1.0/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.1.0/alpine/entrypoint.sh
+++ b/2.1.0/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.1.0/debian/Dockerfile-amd64
+++ b/2.1.0/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.1.0/debian/Dockerfile-arm64
+++ b/2.1.0/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.1.0/debian/Dockerfile-armhf
+++ b/2.1.0/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.1.0%2Fopenhab-2.1.0.zip" \
     OPENHAB_VERSION="2.1.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.1.0/debian/entrypoint.sh
+++ b/2.1.0/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.2.0/alpine/Dockerfile-amd64
+++ b/2.2.0/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.2.0/alpine/Dockerfile-arm64
+++ b/2.2.0/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.2.0/alpine/Dockerfile-armhf
+++ b/2.2.0/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.2.0/alpine/entrypoint.sh
+++ b/2.2.0/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.2.0/debian/Dockerfile-amd64
+++ b/2.2.0/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.2.0/debian/Dockerfile-arm64
+++ b/2.2.0/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.2.0/debian/Dockerfile-armhf
+++ b/2.2.0/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.2.0%2Fopenhab-2.2.0.zip" \
     OPENHAB_VERSION="2.2.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.2.0/debian/entrypoint.sh
+++ b/2.2.0/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.3.0/alpine/Dockerfile-amd64
+++ b/2.3.0/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.3.0/alpine/Dockerfile-arm64
+++ b/2.3.0/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.3.0/alpine/Dockerfile-armhf
+++ b/2.3.0/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.3.0/alpine/entrypoint.sh
+++ b/2.3.0/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.3.0/debian/Dockerfile-amd64
+++ b/2.3.0/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.3.0/debian/Dockerfile-arm64
+++ b/2.3.0/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.3.0/debian/Dockerfile-armhf
+++ b/2.3.0/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.3.0%2Fopenhab-2.3.0.zip" \
     OPENHAB_VERSION="2.3.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.3.0/debian/entrypoint.sh
+++ b/2.3.0/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.4.0/alpine/Dockerfile-amd64
+++ b/2.4.0/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.4.0/alpine/Dockerfile-arm64
+++ b/2.4.0/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.4.0/alpine/Dockerfile-armhf
+++ b/2.4.0/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.4.0/alpine/entrypoint.sh
+++ b/2.4.0/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.4.0/debian/Dockerfile-amd64
+++ b/2.4.0/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.4.0/debian/Dockerfile-arm64
+++ b/2.4.0/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.4.0/debian/Dockerfile-armhf
+++ b/2.4.0/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.4.0%2Fopenhab-2.4.0.zip" \
     OPENHAB_VERSION="2.4.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.4.0/debian/entrypoint.sh
+++ b/2.4.0/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.5.0/alpine/Dockerfile-amd64
+++ b/2.5.0/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.0%2Fopenhab-2.5.0.zip" \
     OPENHAB_VERSION="2.5.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.5.0/alpine/Dockerfile-arm64
+++ b/2.5.0/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.0%2Fopenhab-2.5.0.zip" \
     OPENHAB_VERSION="2.5.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.5.0/alpine/Dockerfile-armhf
+++ b/2.5.0/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.0%2Fopenhab-2.5.0.zip" \
     OPENHAB_VERSION="2.5.0"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.5.0/alpine/entrypoint.sh
+++ b/2.5.0/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.5.0/debian/Dockerfile-amd64
+++ b/2.5.0/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.0%2Fopenhab-2.5.0.zip" \
     OPENHAB_VERSION="2.5.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.5.0/debian/Dockerfile-arm64
+++ b/2.5.0/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.0%2Fopenhab-2.5.0.zip" \
     OPENHAB_VERSION="2.5.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.5.0/debian/Dockerfile-armhf
+++ b/2.5.0/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.0%2Fopenhab-2.5.0.zip" \
     OPENHAB_VERSION="2.5.0"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.5.0/debian/entrypoint.sh
+++ b/2.5.0/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.5.1/alpine/Dockerfile-amd64
+++ b/2.5.1/alpine/Dockerfile-amd64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.1%2Fopenhab-2.5.1.zip" \
     OPENHAB_VERSION="2.5.1"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.5.1/alpine/Dockerfile-arm64
+++ b/2.5.1/alpine/Dockerfile-arm64
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.1%2Fopenhab-2.5.1.zip" \
     OPENHAB_VERSION="2.5.1"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.5.1/alpine/Dockerfile-armhf
+++ b/2.5.1/alpine/Dockerfile-armhf
@@ -6,11 +6,12 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.1%2Fopenhab-2.5.1.zip" \
     OPENHAB_VERSION="2.5.1"
 
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/2.5.1/alpine/entrypoint.sh
+++ b/2.5.1/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/2.5.1/debian/Dockerfile-amd64
+++ b/2.5.1/debian/Dockerfile-amd64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:amd64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.1%2Fopenhab-2.5.1.zip" \
     OPENHAB_VERSION="2.5.1"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.5.1/debian/Dockerfile-arm64
+++ b/2.5.1/debian/Dockerfile-arm64
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:arm64-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.1%2Fopenhab-2.5.1.zip" \
     OPENHAB_VERSION="2.5.1"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.5.1/debian/Dockerfile-armhf
+++ b/2.5.1/debian/Dockerfile-armhf
@@ -11,6 +11,7 @@ FROM multiarch/debian-debootstrap:armhf-buster
 # Set download urls
 ENV \
     JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="8" \
     OPENHAB_URL="https://bintray.com/openhab/mvn/download_file?file_path=org%2Fopenhab%2Fdistro%2Fopenhab%2F2.5.1%2Fopenhab-2.5.1.zip" \
     OPENHAB_VERSION="2.5.1"
 
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/2.5.1/debian/entrypoint.sh
+++ b/2.5.1/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/3.0.0-snapshot/alpine/Dockerfile-amd64
+++ b/3.0.0-snapshot/alpine/Dockerfile-amd64
@@ -6,12 +6,13 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.10
+FROM multiarch/alpine:amd64-v3.11
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
-    OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz" \
+    JAVA_VERSION="11" \
+    OPENHAB_URL="https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="3.0.0-snapshot"
 
 # Set variables and locales
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/3.0.0-snapshot/alpine/Dockerfile-arm64
+++ b/3.0.0-snapshot/alpine/Dockerfile-arm64
@@ -6,12 +6,13 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.10
+FROM multiarch/alpine:arm64-v3.11
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
-    OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz" \
+    JAVA_VERSION="11" \
+    OPENHAB_URL="https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="3.0.0-snapshot"
 
 # Set variables and locales
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/3.0.0-snapshot/alpine/Dockerfile-armhf
+++ b/3.0.0-snapshot/alpine/Dockerfile-armhf
@@ -6,12 +6,13 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.10
+FROM multiarch/alpine:armhf-v3.11
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
-    OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu11.37.48-ca-jdk11.0.6-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="11" \
+    OPENHAB_URL="https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="3.0.0-snapshot"
 
 # Set variables and locales
@@ -65,17 +66,20 @@ RUN apk upgrade --no-cache && \
         su-exec \
         tini \
         ttf-dejavu \
-        openjdk8 \
+        openjdk${JAVA_VERSION} \
         unzip \
         wget \
         zip && \
     chmod u+s /usr/sbin/arping && \
     rm -rf /var/cache/apk/*
 
-# Limit OpenJDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/java-1.8-openjdk'
-RUN rm -r "$JAVA_HOME/jre/lib/security/policy/unlimited" && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "$JAVA_HOME/jre/lib/security/java.security"
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+RUN if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/3.0.0-snapshot/alpine/entrypoint.sh
+++ b/3.0.0-snapshot/alpine/entrypoint.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/3.0.0-snapshot/debian/Dockerfile-amd64
+++ b/3.0.0-snapshot/debian/Dockerfile-amd64
@@ -10,8 +10,9 @@ FROM multiarch/debian-debootstrap:amd64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz" \
-    OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
+    JAVA_URL="https://cdn.azul.com/zulu/bin/zulu11.37.17-ca-jdk11.0.6-linux_x64.tar.gz" \
+    JAVA_VERSION="11" \
+    OPENHAB_URL="https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="3.0.0-snapshot"
 
 # Set variables and locales
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/3.0.0-snapshot/debian/Dockerfile-arm64
+++ b/3.0.0-snapshot/debian/Dockerfile-arm64
@@ -10,8 +10,9 @@ FROM multiarch/debian-debootstrap:arm64-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch64.tar.gz" \
-    OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu11.37.48-ca-jdk11.0.6-linux_aarch64.tar.gz" \
+    JAVA_VERSION="11" \
+    OPENHAB_URL="https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="3.0.0-snapshot"
 
 # Set variables and locales
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/3.0.0-snapshot/debian/Dockerfile-armhf
+++ b/3.0.0-snapshot/debian/Dockerfile-armhf
@@ -10,8 +10,9 @@ FROM multiarch/debian-debootstrap:armhf-buster
 
 # Set download urls
 ENV \
-    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu8.42.0.195-ca-jdk1.8.0_232-linux_aarch32hf.tar.gz" \
-    OPENHAB_URL="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
+    JAVA_URL="https://cdn.azul.com/zulu-embedded/bin/zulu11.37.48-ca-jdk11.0.6-linux_aarch32hf.tar.gz" \
+    JAVA_VERSION="11" \
+    OPENHAB_URL="https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" \
     OPENHAB_VERSION="3.0.0-snapshot"
 
 # Set variables and locales
@@ -74,10 +75,16 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/java-8'
+ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
+# Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
 RUN wget -nv -O /tmp/java.tar.gz "${JAVA_URL}" && \
-    mkdir "${JAVA_HOME}" && \
+    mkdir -p "${JAVA_HOME}" && \
     tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+    if [ "${JAVA_VERSION}" = "8" ]; then \
+        sed -i 's/^#crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/jre/lib/security/java.security"; \
+    elif [ "${JAVA_VERSION}" = "11" ]; then \
+        sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"; \
+    fi && \
     rm /tmp/java.tar.gz && \
     update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
     update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50

--- a/3.0.0-snapshot/debian/entrypoint.sh
+++ b/3.0.0-snapshot/debian/entrypoint.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Newer Docker versions (1.10.0+) have multi-architecture support which allows for
 **Distributions:**
 
 * `debian` for Debian 10 "buster" (default when not specified in tag)
-* `alpine` for Alpine 3.10
+* `alpine` for Alpine 3.11
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).
 

--- a/entrypoint-alpine.sh
+++ b/entrypoint-alpine.sh
@@ -4,11 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -d "${JAVA_HOME}/jre/lib/security/policy/unlimited" ]; then
-  echo "Installing OpenJDK unlimited strength cryptography policy..."
-  mkdir "${JAVA_HOME}/jre/lib/security/policy/unlimited"
-  apk fix --no-cache openjdk8-jre-lib
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "${JAVA_VERSION}" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart

--- a/entrypoint-debian.sh
+++ b/entrypoint-debian.sh
@@ -4,12 +4,15 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -euo pipefail
 IFS=$'\n\t'
 
-# Install Java unlimited strength cryptography
-if [ "${CRYPTO_POLICY}" = "unlimited" ] && [ ! -f "${JAVA_HOME}/jre/lib/security/README.txt" ]; then
-  echo "Installing Zulu Cryptography Extension Kit (\"CEK\")..."
-  wget -q -O /tmp/ZuluJCEPolicies.zip https://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip
-  unzip -jo -d "${JAVA_HOME}/jre/lib/security" /tmp/ZuluJCEPolicies.zip
-  rm /tmp/ZuluJCEPolicies.zip
+# Configure Java unlimited strength cryptography
+if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
+  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  if [ "${JAVA_VERSION}" = "8" ]; then
+    java_security_file="${JAVA_HOME}/jre/lib/security/java.security"
+  elif [ "$JAVA_VERSION" = "11" ]; then
+    java_security_file="${JAVA_HOME}/conf/security/java.security"
+  fi
+  sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${java_security_file}"
 fi
 
 # Deleting instance.properties to avoid karaf PID conflict on restart


### PR DESCRIPTION
* Uses Zulu JDK/OpenJDK 11 in the openHAB 3 images
* Upgrades the Alpine images to v3.11
* Fixes the SNAPSHOT download URLs for openHAB 3
* Fixes `CRYPTO_POLICY` for the Debian images due to Zulu JDK changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/274)
<!-- Reviewable:end -->
