### PR TITLE
Downgrade to Alpine v3.10, fail build when commands fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
 services:
   - docker
 before_install:
+  - set -e
   - ./update-docker-files.sh
   - ./install-manifest-tool.sh
   - docker info

--- a/1.8.3/alpine/Dockerfile-amd64
+++ b/1.8.3/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/1.8.3/alpine/Dockerfile-arm64
+++ b/1.8.3/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/1.8.3/alpine/Dockerfile-armhf
+++ b/1.8.3/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.0.0/alpine/Dockerfile-amd64
+++ b/2.0.0/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.0.0/alpine/Dockerfile-arm64
+++ b/2.0.0/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.0.0/alpine/Dockerfile-armhf
+++ b/2.0.0/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.1.0/alpine/Dockerfile-amd64
+++ b/2.1.0/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.1.0/alpine/Dockerfile-arm64
+++ b/2.1.0/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.1.0/alpine/Dockerfile-armhf
+++ b/2.1.0/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.2.0/alpine/Dockerfile-amd64
+++ b/2.2.0/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.2.0/alpine/Dockerfile-arm64
+++ b/2.2.0/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.2.0/alpine/Dockerfile-armhf
+++ b/2.2.0/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.3.0/alpine/Dockerfile-amd64
+++ b/2.3.0/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.3.0/alpine/Dockerfile-arm64
+++ b/2.3.0/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.3.0/alpine/Dockerfile-armhf
+++ b/2.3.0/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.4.0/alpine/Dockerfile-amd64
+++ b/2.4.0/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.4.0/alpine/Dockerfile-arm64
+++ b/2.4.0/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.4.0/alpine/Dockerfile-armhf
+++ b/2.4.0/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.0/alpine/Dockerfile-amd64
+++ b/2.5.0/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.0/alpine/Dockerfile-arm64
+++ b/2.5.0/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.0/alpine/Dockerfile-armhf
+++ b/2.5.0/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.1/alpine/Dockerfile-amd64
+++ b/2.5.1/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.1/alpine/Dockerfile-arm64
+++ b/2.5.1/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.1/alpine/Dockerfile-armhf
+++ b/2.5.1/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.2-snapshot/alpine/Dockerfile-amd64
+++ b/2.5.2-snapshot/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.2-snapshot/alpine/Dockerfile-arm64
+++ b/2.5.2-snapshot/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/2.5.2-snapshot/alpine/Dockerfile-armhf
+++ b/2.5.2-snapshot/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/3.0.0-snapshot/alpine/Dockerfile-amd64
+++ b/3.0.0-snapshot/alpine/Dockerfile-amd64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:amd64-v3.11
+FROM multiarch/alpine:amd64-v3.10
 
 # Set download urls
 ENV \

--- a/3.0.0-snapshot/alpine/Dockerfile-arm64
+++ b/3.0.0-snapshot/alpine/Dockerfile-arm64
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:arm64-v3.11
+FROM multiarch/alpine:arm64-v3.10
 
 # Set download urls
 ENV \

--- a/3.0.0-snapshot/alpine/Dockerfile-armhf
+++ b/3.0.0-snapshot/alpine/Dockerfile-armhf
@@ -6,7 +6,7 @@
 #                       PLEASE DO NOT EDIT IT DIRECTLY.
 # ------------------------------------------------------------------------------
 #
-FROM multiarch/alpine:armhf-v3.11
+FROM multiarch/alpine:armhf-v3.10
 
 # Set download urls
 ENV \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Newer Docker versions (1.10.0+) have multi-architecture support which allows for
 **Distributions:**
 
 * `debian` for Debian 10 "buster" (default when not specified in tag)
-* `alpine` for Alpine 3.11
+* `alpine` for Alpine 3.10
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).
 

--- a/update-docker-files.sh
+++ b/update-docker-files.sh
@@ -93,7 +93,7 @@ print_baseimage() {
 	# Set Docker base image based on distributions
 	case $base in
 	alpine)
-		base_image="alpine:$arch-v3.11"
+		base_image="alpine:$arch-v3.10"
 		;;
 	debian)
 		base_image="debian-debootstrap:$arch-buster"

--- a/update-travis-config.sh
+++ b/update-travis-config.sh
@@ -24,6 +24,7 @@ print_static_configuration() {
 	services:
 	  - docker
 	before_install:
+	  - set -e
 	  - ./update-docker-files.sh
 	  - ./install-manifest-tool.sh
 	  - docker info


### PR DESCRIPTION
The Alpine v3.11 armhf image is missing, see https://github.com/multiarch/alpine/issues/30.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/280)
<!-- Reviewable:end -->
