### PR TITLE
Make sure README.md does not exceed 25k char limit of Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - docker info
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
   - source ./update-functions.sh
+  - validate_readme_constraints
   - ARCHES="$(arches $VERSION $DIST)"
 install:
   - for ARCH in $ARCHES; do

--- a/README.md
+++ b/README.md
@@ -71,11 +71,7 @@ Comments, suggestions and contributions are welcome!
 * `2.2.0` Stable openHAB 2.2.0 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.2.0/debian/Dockerfile-amd64))
 * `2.3.0` Stable openHAB 2.3.0 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.3.0/debian/Dockerfile-amd64))
 * `2.4.0` Stable openHAB 2.4.0 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.4.0/debian/Dockerfile-amd64))
-* `2.5.0` Stable openHAB 2.5.0 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.0/debian/Dockerfile-amd64))
-* `2.5.1` Stable openHAB 2.5.1 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.1/debian/Dockerfile-amd64))
-* `2.5.2` Stable openHAB 2.5.2 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.2/debian/Dockerfile-amd64))
-* `2.5.3` Stable openHAB 2.5.3 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.3/debian/Dockerfile-amd64))
-* `2.5.4` Stable openHAB 2.5.4 version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.4/debian/Dockerfile-amd64))
+* `2.5.0` - `2.5.4` Stable openHAB 2.5.x version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.4/debian/Dockerfile-amd64))
 * `2.5.5-snapshot` Experimental openHAB 2.5.5 SNAPSHOT version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/2.5.5-snapshot/debian/Dockerfile-amd64))
 * `3.0.0-snapshot` Experimental openHAB 3.0.0 SNAPSHOT version ([Dockerfile](https://github.com/openhab/openhab-docker/blob/master/3.0.0-snapshot/debian/Dockerfile-amd64))
 

--- a/update-functions.sh
+++ b/update-functions.sh
@@ -54,3 +54,11 @@ last_milestone_version() {
 build_versions() {
 	echo "$(stable_versions) $(milestone_versions) $(snapshot_versions)"
 }
+
+validate_readme_constraints() {
+	count=$(wc -m <README.md)
+	if [[ $count -ge 25000 ]]; then
+		echo "README.md contains $count characters which exceeds the 25000 character limit of Docker Hub"
+		exit 1;
+	fi
+}

--- a/update-readme.sh
+++ b/update-readme.sh
@@ -17,6 +17,11 @@ generate_version_list() {
 		2.*-snapshot|3.*-snapshot)
 			echo "* \`$version\` Experimental openHAB $(echo $version | sed 's/-snapshot/ SNAPSHOT/g') version ([Dockerfile]($url))"
 			;;
+		$(last_stable_version))
+			echo "* \`2.5.0\` - \`$version\` Stable openHAB $(echo $version | sed -E 's/^([0-9]+)\.([0-9])+\.([0-9])+$/\1\.\2\.x/g') version ([Dockerfile]($url))"
+			;;
+		2.5.*)
+			;;
 		*)
 			echo "* \`$version\` Stable openHAB $version version ([Dockerfile]($url))"
 			;;
@@ -48,5 +53,6 @@ echo -n "Writing $file... "
 
 update_version_list
 update_last_stable_version
+validate_readme_constraints
 
 echo "done"

--- a/update-travis-config.sh
+++ b/update-travis-config.sh
@@ -30,6 +30,7 @@ print_static_configuration() {
 	  - docker info
 	  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	  - source ./update-functions.sh
+	  - validate_readme_constraints
 	  - ARCHES="$(arches $VERSION $DIST)"
 	install:
 	  - for ARCH in $ARCHES; do


### PR DESCRIPTION
Docker Hub silently ignores Readme content exceeding 25k chars. It doesn't give any error message and keeps showing the old Readme contents as if it was never updated at all. :disappointed: 

See also: https://github.com/docker/hub-feedback/issues/238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/291)
<!-- Reviewable:end -->
