### PR TITLE
Sync README.md automatically to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ after_success:
             docker push $DOCKER_REPO:$VERSION-$ARCH-$DIST;
         done;
         manifest-tool push from-spec $VERSION/$DIST/manifest.yml;
+        if [ "${SYNC_README:=false}" == "true" ] && [ "$VERSION" == "$(last_stable_version)" ] && [ "$DIST" == "debian" ]; then
+            ./sync-docker-hub-readme.sh;
+        fi
     fi
 jobs:
   fast_finish: true

--- a/sync-docker-hub-readme.sh
+++ b/sync-docker-hub-readme.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eo pipefail
+
+# This script is based on the GitHub Docker Hub Description action.
+# See: https://github.com/peter-evans/dockerhub-description/blob/master/entrypoint.sh
+
+# Acquire token for Docker Hub API
+LOGIN_PAYLOAD="{\"username\": \"${DOCKER_USERNAME}\", \"password\": \"${DOCKER_PASSWORD}\"}"
+TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d "${LOGIN_PAYLOAD}" https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+# Send a PATCH request to update the description of the repository
+echo "Updating README for $DOCKER_REPO on Docker Hub"
+README_FILEPATH="./README.md"
+REPO_URL="https://hub.docker.com/v2/repositories/${DOCKER_REPO}/"
+RESPONSE_CODE=$(curl -s --write-out %{response_code} --output /dev/null -H "Authorization: JWT ${TOKEN}" -X PATCH --data-urlencode full_description@${README_FILEPATH} ${REPO_URL})
+
+if [ $RESPONSE_CODE -eq 200 ]; then
+    echo "Successfully updated README for $DOCKER_REPO on Docker Hub"
+    exit 0
+else
+    echo "Failed to update README for $DOCKER_REPO on Docker Hub (Response code: $RESPONSE_CODE)"
+    exit 1
+fi

--- a/update-functions.sh
+++ b/update-functions.sh
@@ -57,8 +57,8 @@ build_versions() {
 
 validate_readme_constraints() {
 	count=$(wc -m <README.md)
-	if [[ $count -ge 25000 ]]; then
+	if [ $count -gt 25000 ]; then
 		echo "README.md contains $count characters which exceeds the 25000 character limit of Docker Hub"
-		exit 1;
+		exit 1
 	fi
 }

--- a/update-travis-config.sh
+++ b/update-travis-config.sh
@@ -44,6 +44,9 @@ print_static_configuration() {
 	            docker push $DOCKER_REPO:$VERSION-$ARCH-$DIST;
 	        done;
 	        manifest-tool push from-spec $VERSION/$DIST/manifest.yml;
+	        if [ "${SYNC_README:=false}" == "true" ] && [ "$VERSION" == "$(last_stable_version)" ] && [ "$DIST" == "debian" ]; then
+	            ./sync-docker-hub-readme.sh;
+	        fi
 	    fi
 	jobs:
 	  fast_finish: true


### PR DESCRIPTION
With the changes in this PR, Travis will automatically sync the `README.md` to Docker Hub on the master branch when the `latest` (stable Debian) container is pushed.

It will only do this if the `SYNC_README` variable is set to `true` in the Travis settings. This allows for disabling it when Travis CI is used on forks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/292)
<!-- Reviewable:end -->
