### PR TITLE
Undo Travis CI SNAPSHOT download workaround

### DIFF
--- a/2.5.8-snapshot/alpine/Dockerfile
+++ b/2.5.8-snapshot/alpine/Dockerfile
@@ -81,8 +81,7 @@ RUN if [ "${JAVA_VERSION}" = "8" ]; then \
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
-RUN timestamped_version=$(wget -qO- "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/2.5.8-SNAPSHOT/maven-metadata.xml" | grep -m 1 '<value>' | sed -E 's/.*<value>(.+)<\/value>/\1/') && \
-    wget -nv -O /tmp/openhab.zip "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/2.5.8-SNAPSHOT/openhab-${timestamped_version}.zip" && \
+RUN wget -nv -O /tmp/openhab.zip "https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.8-SNAPSHOT.zip" && \
     unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
     if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \

--- a/2.5.8-snapshot/debian/Dockerfile
+++ b/2.5.8-snapshot/debian/Dockerfile
@@ -97,8 +97,7 @@ RUN mkdir -p "${JAVA_HOME}" && \
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
-RUN timestamped_version=$(wget -qO- "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/2.5.8-SNAPSHOT/maven-metadata.xml" | grep -m 1 '<value>' | sed -E 's/.*<value>(.+)<\/value>/\1/') && \
-    wget -nv -O /tmp/openhab.zip "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/2.5.8-SNAPSHOT/openhab-${timestamped_version}.zip" && \
+RUN wget -nv -O /tmp/openhab.zip "https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-2.5.8-SNAPSHOT.zip" && \
     unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
     if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \

--- a/3.0.0-snapshot/alpine/Dockerfile
+++ b/3.0.0-snapshot/alpine/Dockerfile
@@ -81,8 +81,7 @@ RUN if [ "${JAVA_VERSION}" = "8" ]; then \
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
-RUN timestamped_version=$(wget -qO- "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/3.0.0-SNAPSHOT/maven-metadata.xml" | grep -m 1 '<value>' | sed -E 's/.*<value>(.+)<\/value>/\1/') && \
-    wget -nv -O /tmp/openhab.zip "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/3.0.0-SNAPSHOT/openhab-${timestamped_version}.zip" && \
+RUN wget -nv -O /tmp/openhab.zip "https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" && \
     unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
     if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \

--- a/3.0.0-snapshot/debian/Dockerfile
+++ b/3.0.0-snapshot/debian/Dockerfile
@@ -97,8 +97,7 @@ RUN mkdir -p "${JAVA_HOME}" && \
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!
-RUN timestamped_version=$(wget -qO- "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/3.0.0-SNAPSHOT/maven-metadata.xml" | grep -m 1 '<value>' | sed -E 's/.*<value>(.+)<\/value>/\1/') && \
-    wget -nv -O /tmp/openhab.zip "https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/3.0.0-SNAPSHOT/openhab-${timestamped_version}.zip" && \
+RUN wget -nv -O /tmp/openhab.zip "https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-3.0.0-SNAPSHOT.zip" && \
     unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \
     rm /tmp/openhab.zip && \
     if [ ! -f "${OPENHAB_HOME}/runtime/bin/update.lst" ]; then touch "${OPENHAB_HOME}/runtime/bin/update.lst"; fi && \

--- a/update-docker-files.sh
+++ b/update-docker-files.sh
@@ -9,10 +9,6 @@ openhab_milestone_url='https://openhab.jfrog.io/openhab/libs-milestone-local/org
 openhab2_snapshot_url='https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${version}.zip'
 openhab3_snapshot_url='https://ci.openhab.org/job/openHAB3-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${version}.zip'
 
-# Maven download URLs
-openhab_mvn_metadata_url='https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/${version}/maven-metadata.xml'
-openhab_mvn_snapshot_url='https://openhab.jfrog.io/openhab/libs-snapshot-local/org/openhab/distro/openhab/${version}/openhab-${timestamped_version}.zip'
-
 # Zulu 8 download URLs
 zulu8_amd64_url='https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-linux_x64.tar.gz'
 zulu8_armhf_url='https://cdn.azul.com/zulu-embedded/bin/zulu8.46.0.225-ca-jdk8.0.252-linux_aarch32hf.tar.gz'
@@ -232,28 +228,9 @@ print_openhab_install() {
 	# Set permissions for openHAB. Export TERM variable. See issue #30 for details!
 EOI
 
-	# Travis CI fails to download from ci.openhab.org so download Maven snapshots as workaround
-	case $version in
-	*-snapshot)
-		original_version=$version
-		version=${version/snapshot/SNAPSHOT}
-		timestamped_version='${timestamped_version}'
-		metadata_url="$(eval "echo $openhab_mvn_metadata_url")"
-		openhab_url="$(eval "echo $openhab_mvn_snapshot_url")"
-
-		cat >> $1 <<-EOI
-		RUN timestamped_version=\$(wget -qO- "${metadata_url}" | grep -m 1 '<value>' | sed -E 's/.*<value>(.+)<\/value>/\1/') && \\
-		    wget -nv -O /tmp/openhab.zip "${openhab_url}" && \\
+	cat >> $1 <<-EOI
+	RUN wget -nv -O /tmp/openhab.zip "${openhab_url}" && \\
 EOI
-
-		version=$original_version
-		;;
-	*)
-		cat >> $1 <<-EOI
-		RUN wget -nv -O /tmp/openhab.zip "${openhab_url}" && \\
-EOI
-		;;
-	esac
 
 	cat >> $1 <<-'EOI'
 	    unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \


### PR DESCRIPTION
The connections to ci.openhab.org are no longer blocked in the Travis CI infrastructure.

Fixes #297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/303)
<!-- Reviewable:end -->
