### PR TITLE
Update snapshot version logic

### DIFF
--- a/helper-functions
+++ b/helper-functions
@@ -10,7 +10,7 @@ get_released_versions_from_tags() {
 }
 
 get_snapshot_versions_from_poms() {
-	local branch_names="$(git ls-remote --refs --heads "git://github.com/${DISTRO_REPO}.git" | grep -E '.+/heads/(main|master|[0-9]+\.[0-9]+\.x)$' | sed -E 's#.+/heads/(.+)#\1#g')"
+	local branch_names="$(git ls-remote --refs --heads "git://github.com/${DISTRO_REPO}.git" | grep -E '.+/heads/(main|master|2\.5\.x)$' | sed -E 's#.+/heads/(.+)#\1#g')"
 	for branch_name in $branch_names; do
 		curl -sS "https://raw.githubusercontent.com/${DISTRO_REPO}/${branch_name}/pom.xml" | grep -E '^    <version>' | grep 'SNAPSHOT' | sed -E 's#.+<version>(.+)-SNAPSHOT</version>#\1-snapshot#g' || echo ""
 	done


### PR DESCRIPTION
There won't be any 3.0.x-snapshot builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/341)
<!-- Reviewable:end -->
