### PR TITLE
Added healthcheck in alpine and debian dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -94,7 +94,7 @@ VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 EXPOSE 8080 8443 8101 5007
 
 # Set healthcheck
-HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:${OPENHAB_HTTP_PORT}/ || exit 1
 
 # Set working directory and entrypoint
 WORKDIR ${OPENHAB_HOME}

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -93,6 +93,9 @@ VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
+# Set healthcheck
+HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+
 # Set working directory and entrypoint
 WORKDIR ${OPENHAB_HOME}
 COPY entrypoint /entrypoint

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -110,7 +110,7 @@ VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 EXPOSE 8080 8443 8101 5007
 
 # Set healthcheck
-HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:${OPENHAB_HTTP_PORT}/ || exit 1
 
 # Set working directory and entrypoint
 WORKDIR ${OPENHAB_HOME}

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -109,6 +109,9 @@ VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 # Expose HTTP, HTTPS, Console and LSP ports
 EXPOSE 8080 8443 8101 5007
 
+# Set healthcheck
+HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+
 # Set working directory and entrypoint
 WORKDIR ${OPENHAB_HOME}
 COPY entrypoint /entrypoint


### PR DESCRIPTION
Hello, I hope this is wanted. I haven't found any reference to health checks in the repo nor in the openhab discussion forum. I did find one compose file that implemented the healthcheck with the docker run command. But I though it's best to directly implement it in the official dockerfiles. I successfully tested the debian version on a raspberry pi.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openhab/openhab-docker/351)
<!-- Reviewable:end -->
