### PR TITLE
Add EXTRA_SHELL_OPTS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ The debug mode is started with the command:
 ## Environment variables
 
 * `EXTRA_JAVA_OPTS`=""
+* `EXTRA_SHELL_OPTS`=""
 * `LC_ALL`=en_US.UTF-8
 * `LANG`=en_US.UTF-8
 * `LANGUAGE`=en_US.UTF-8

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,6 +8,7 @@ ARG OPENHAB_VERSION
 ENV \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
+    EXTRA_SHELL_OPTS="" \
     GROUP_ID="9001" \
     JAVA_VERSION="$JAVA_VERSION" \
     KARAF_EXEC="exec" \

--- a/alpine/entrypoint
+++ b/alpine/entrypoint
@@ -1,7 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
 
 interactive=$(if test -t 0; then echo true; else echo false; fi)
-set -euo pipefail
+set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
 # Configure Java unlimited strength cryptography

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -8,6 +8,7 @@ ARG OPENHAB_VERSION
 ENV \
     CRYPTO_POLICY="limited" \
     EXTRA_JAVA_OPTS="" \
+    EXTRA_SHELL_OPTS="" \
     GROUP_ID="9001" \
     JAVA_VERSION="$JAVA_VERSION" \
     KARAF_EXEC="exec" \

--- a/debian/entrypoint
+++ b/debian/entrypoint
@@ -1,7 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
 
 interactive=$(if test -t 0; then echo true; else echo false; fi)
-set -euo pipefail
+set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
 # Configure Java unlimited strength cryptography


### PR DESCRIPTION
Allows for customizing the shell options used by the entrypoint script.
E.g. set it to `+x` to disable the trace logging or set it to `-v` to also print shell input lines.

Fixes #346