### PR TITLE
Upgrade base images and build tools

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        run: docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ Comments, suggestions and contributions are welcome!
 
 **Distributions:**
 
-* `debian` for Debian 10 "buster" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
+* `debian` for Debian 11 "bullseye" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
 * `alpine` for Alpine 3.14 ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/alpine/Dockerfile))
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).
+Older container images may use older versions of the Debian and Alpine base images.
 
 If you are unsure about what your needs are, you probably want to use `openhab/openhab:3.1.0`.
 
@@ -523,7 +524,7 @@ First enable BuildKit support, configure QEMU binary formats and a builder using
 ```shell
 $ echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
 $ export DOCKER_CLI_EXPERIMENTAL=enabled
-$ docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+$ docker run --privileged --rm tonistiigi/binfmt:qemu-v6.1.0 --install all
 $ sudo systemctl restart docker
 $ docker buildx create --name builder --use
 ```

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.11-slim
+FROM debian:11.1-slim
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/helper-functions
+++ b/helper-functions
@@ -182,26 +182,23 @@ validate_readme_constraints() {
 }
 
 update_dockerhub_readme() {
-	# Acquire token for Docker Hub API
-	local login_payload="{\"username\": \"${DOCKER_USERNAME}\", \"password\": \"${DOCKER_PASSWORD}\"}"
-	local token=$(curl -s -H "Content-Type: application/json" -X POST -d "${login_payload}" https://hub.docker.com/v2/users/login/ | sed -E 's#\{"token": "(.+)"\}#\1#g')
+	if [ "$(docker info 2>&1 | grep 'pushrm: Push Readme to container registry' | wc -l)" -eq "0" ]; then
+		# The pushrm plugin is available from https://github.com/christian-korneck/docker-pushrm
+		echo "Failed to update README for $(docker_repo) on Docker Hub (pushrm Docker CLI plugin not installed)" >&2
+		exit 1
+	fi
 
-	# Send a PATCH request to update the description of the repository
-	echo "Updating README for $(docker_repo) on Docker Hub"
-	local readme_filepath="./README.md"
-	local repo_url="https://hub.docker.com/v2/repositories/$(docker_repo)/"
-	local response_code=$(curl -s --write-out %{response_code} --output /dev/null -H "Authorization: JWT ${token}" -X PATCH --data-urlencode full_description@${readme_filepath} ${repo_url})
-
-	if [ $response_code -eq 200 ]; then
+	if docker pushrm $(docker_repo); then
 		echo "Successfully updated README for $(docker_repo) on Docker Hub"
 	else
-		echo "Failed to update README for $(docker_repo) on Docker Hub (Response code: $response_code)" >&2
+		echo "Failed to update README for $(docker_repo) on Docker Hub" >&2
 		exit 1
 	fi
 }
 
 prepare_builder() {
 	if [ "$BUILDER" == "" ]; then
+		docker run --privileged --rm tonistiigi/binfmt:qemu-v6.1.0 --install all &> /dev/null
 		(docker buildx inspect builder &> /dev/null && echo -e "\nReusing existing builder") || \
 			(docker buildx create --name builder --use &> /dev/null && echo -e "\nCreated builder")
 		BUILDER="builder"


### PR DESCRIPTION
Updates:

* Alpine to 3.14.3
* Debian to 11.1
* binfmt to tonistiigi/binfmt:qemu-v6.1.0 (required for building Debian 11 ARM images with buildx)

Furthermore the [pushrm](https://github.com/christian-korneck/docker-pushrm) Docker CLI plugin is now used for updating the README on Docker Hub.