### PR TITLE
Add iputils-ping to Debian image

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && \
         curl \
         fontconfig \
         gosu \
+        iputils-ping \
         libcap2-bin \
         locales \
         locales-all \


### PR DESCRIPTION
It only adds 50 kB to the image and ping is also supported in the Alpine image.

Fixes #374