### PR TITLE
Explain how to setup console logger in OH3 before OH2

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,12 +326,12 @@ When the container runs in server mode you can also add a console logger so it p
 
 `docker logs openhab`
 
+To use a console logger with openHAB 3.x, edit `userdata/etc/log4j2.xml` and add the following appender to the "Root logger" and "openhab.event" logger configurations: `<AppenderRef ref="STDOUT"/>`
+
 To use a console logger with openHAB 2.x, edit `userdata/etc/org.ops4j.pax.logging.cfg` and then:
 
 * Update the appenderRefs line to: `log4j2.rootLogger.appenderRefs = out, osgi, console`
 * Add the following line: `log4j2.rootLogger.appenderRef.console.ref = STDOUT`
-
-To use a console logger with openHAB 3.x, edit `userdata/etc/log4j2.xml` and add the following appender to the "Root logger" and "openhab.event" logger configurations: `<AppenderRef ref="STDOUT"/>`
 
 #### Regular mode
 


### PR DESCRIPTION
Most users use OH3, so don't first bother them with how this was done in OH2.