### PR TITLE
Replace Zulu with Temurin JDK and prevent env var issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,10 +386,7 @@ You can obtain your user and group ID by executing the `id --user` and `id --gro
 Due to local laws and export restrictions the containers use Java with a limited cryptographic strength policy.
 Some openHAB functionality may depend on unlimited strength which can be enabled by configuring the environment variable `CRYPTO_POLICY`=unlimited
 
-Before enabling this make sure this is allowed by local laws and you agree with the applicable license and terms:
-
-* Debian: [Zulu (Cryptography Extension Kit)](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-cryptography-extension-kit)
-* Alpine: [OpenJDK (Cryptographic Cautions)](https://openjdk.java.net/groups/security)
+Before enabling this make sure this is allowed by local laws and you agree with the applicable license and terms (see [OpenJDK (Cryptographic Cautions)](https://openjdk.java.net/groups/security)).
 
 The following addons are known to depend on the unlimited cryptographic strength policy:
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -10,7 +10,6 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     EXTRA_SHELL_OPTS="" \
     GROUP_ID="9001" \
-    JAVA_VERSION="$JAVA_VERSION" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
@@ -22,7 +21,6 @@ ENV \
     OPENHAB_HTTPS_PORT="8443" \
     OPENHAB_LOGDIR="/openhab/userdata/logs" \
     OPENHAB_USERDATA="/openhab/userdata" \
-    OPENHAB_VERSION="$OPENHAB_VERSION" \
     USER_ID="9001"
 
 # Basic build-time metadata as defined at http://label-schema.org
@@ -63,8 +61,8 @@ RUN apk update --no-cache && \
     rm -rf /var/cache/apk/*
 
 # Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
-RUN sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"
+RUN JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk*) && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/alpine/entrypoint
+++ b/alpine/entrypoint
@@ -4,9 +4,11 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
+export JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk*)
+
 # Configure Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
-  echo "Configuring OpenJDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  echo "Configuring Java unlimited strength cryptography policy..."
   sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${JAVA_HOME}/conf/security/java.security"
 fi
 
@@ -27,8 +29,7 @@ fi
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
-# The instance.properties file in openHAB 2.x/3.x is installed in the tmp
-# directory
+# The instance.properties file in openHAB 3.x is installed in the tmp directory
 rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems

--- a/alpine/update
+++ b/alpine/update
@@ -8,7 +8,7 @@ setup() {
   fi
 
   current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
-  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  oh_version="$(awk '/openhab-distro/{print $3}' "/openhab/dist/userdata/etc/version.properties")"
   milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
 
   # Download snapshots from Jenkins and download milestones and releases using openHAB redirect.

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && \
 
 # Install java
 # Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
+RUN wget -nv -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y temurin-${JAVA_VERSION}-jdk && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -10,7 +10,6 @@ ENV \
     EXTRA_JAVA_OPTS="" \
     EXTRA_SHELL_OPTS="" \
     GROUP_ID="9001" \
-    JAVA_VERSION="$JAVA_VERSION" \
     KARAF_EXEC="exec" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
@@ -22,7 +21,6 @@ ENV \
     OPENHAB_HTTPS_PORT="8443" \
     OPENHAB_LOGDIR="/openhab/userdata/logs" \
     OPENHAB_USERDATA="/openhab/userdata" \
-    OPENHAB_VERSION="$OPENHAB_VERSION" \
     USER_ID="9001"
 
 # Basic build-time metadata as defined at http://label-schema.org
@@ -64,25 +62,17 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install java
-ENV JAVA_HOME='/usr/lib/jvm/default-jvm'
 # Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-RUN mkdir -p "${JAVA_HOME}" && \
-    zulu11_version='zulu11.56.19-ca-jdk11.0.15' && \
-    zulu11_x86_64_url="https://cdn.azul.com/zulu/bin/${zulu11_version}-linux_x64.tar.gz" && \
-    zulu11_armv7l_url="https://cdn.azul.com/zulu-embedded/bin/${zulu11_version}-linux_aarch32hf.tar.gz" && \
-    zulu11_aarch64_url="https://cdn.azul.com/zulu-embedded/bin/${zulu11_version}-linux_aarch64.tar.gz" && \
-    zulu17_version='zulu17.34.19-ca-jdk17.0.3' && \
-    zulu17_x86_64_url="https://cdn.azul.com/zulu/bin/${zulu17_version}-linux_x64.tar.gz" && \
-    zulu17_armv7l_url="https://cdn.azul.com/zulu-embedded/bin/${zulu17_version}-linux_aarch32hf.tar.gz" && \
-    zulu17_aarch64_url="https://cdn.azul.com/zulu-embedded/bin/${zulu17_version}-linux_aarch64.tar.gz" && \
-    url_var="zulu${JAVA_VERSION}_$(arch)_url" && \
-    eval "java_url=\$$url_var" && \
-    wget -nv -O /tmp/java.tar.gz "${java_url}" && \
-    tar --exclude='demo' --exclude='sample' --exclude='src.zip' -xf /tmp/java.tar.gz --strip-components=1 -C "${JAVA_HOME}" && \
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y temurin-${JAVA_VERSION}-jdk && \
+    JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk*) && \
     sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security" && \
-    rm /tmp/java.tar.gz && \
-    update-alternatives --install /usr/bin/java java "${JAVA_HOME}/bin/java" 50 && \
-    update-alternatives --install /usr/bin/javac javac "${JAVA_HOME}/bin/javac" 50
+    rm "${JAVA_HOME}/src.zip" && \
+    rm "${JAVA_HOME}/lib/src.zip" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/debian/entrypoint
+++ b/debian/entrypoint
@@ -4,9 +4,11 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
+export JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk*)
+
 # Configure Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
-  echo "Configuring Zulu JDK ${JAVA_VERSION} unlimited strength cryptography policy..."
+  echo "Configuring Java unlimited strength cryptography policy..."
   sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${JAVA_HOME}/conf/security/java.security"
 fi
 
@@ -19,8 +21,7 @@ fi
 # See: https://github.com/openhab/openhab-docker/issues/99
 rm -f "${OPENHAB_HOME}/runtime/instances/instance.properties"
 
-# The instance.properties file in openHAB 2.x/3.x is installed in the tmp
-# directory
+# The instance.properties file in openHAB 3.x is installed in the tmp directory
 rm -f "${OPENHAB_USERDATA}/tmp/instances/instance.properties"
 
 # Add openhab user & handle possible device groups for different host systems

--- a/debian/update
+++ b/debian/update
@@ -8,7 +8,7 @@ setup() {
   fi
 
   current_version="$(awk '/openhab-distro/{print $3}' "${OPENHAB_USERDATA}/etc/version.properties")"
-  oh_version="$(echo "${OPENHAB_VERSION}" | sed 's/snapshot/SNAPSHOT/')"
+  oh_version="$(awk '/openhab-distro/{print $3}' "/openhab/dist/userdata/etc/version.properties")"
   milestone_version="$(echo "${oh_version}" | awk -F'.' '{print $4}')"
 
   # Download snapshots from Jenkins and download milestones and releases using openHAB redirect.


### PR DESCRIPTION
The Temurin JDK is easier to install because it supports all architectures using an APT repo.
It is also more open source compared to the Zulu JDK, for building it yourself, see: https://github.com/adoptium/temurin-build

With these changes the JAVA_HOME, JAVA_VERSION, OPENHAB_VERSION environment variables are no longer exposed/used to prevent upgrade issues when the container is managed by UIs that persist all env default values like Portainer.

Closes #393