### PR TITLE
Upgrade to Alpine 3.16.2

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Addresses CVE-2022-37434, see:

https://security.alpinelinux.org/vuln/CVE-2022-37434