### PR TITLE
Fix JVM crashes and insufficient memory issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The openHAB Docker images are available in the [openhab/openhab](https://hub.doc
 
 **Distributions:**
 
-* `debian` for Debian 12 "bookworm" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
+* `debian` for Debian 11 "bullseye" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
 * `alpine` for Alpine 3.18 ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/alpine/Dockerfile))
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12.0-slim
+FROM debian:11.7-slim
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -50,6 +50,7 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
+        openjdk-${JAVA_VERSION}-jre-headless \
         procps \
         tini \
         unzip \
@@ -61,18 +62,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install java
 # Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-RUN wget -nv -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y temurin-${JAVA_VERSION}-jdk && \
-    JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk*) && \
-    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security" && \
-    rm "${JAVA_HOME}/src.zip" && \
-    rm "${JAVA_HOME}/lib/src.zip" && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk* | tail -n 1) && \
+    sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"
 
 # Install openHAB
 # Set permissions for openHAB. Export TERM variable. See issue #30 for details!

--- a/debian/entrypoint
+++ b/debian/entrypoint
@@ -4,17 +4,13 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
-export JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk*)
+export JAVA_HOME=$(ls -d /usr/lib/jvm/*jdk* | tail -n 1)
 
 # Configure Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ]; then
   echo "Configuring Java unlimited strength cryptography policy..."
   sed -i 's/^crypto.policy=limited/crypto.policy=unlimited/' "${JAVA_HOME}/conf/security/java.security"
 fi
-
-# Make sure the Adoptium cacerts are populated
-# p11-kit cannot find any modules during the linux/arm/v7 build
-/etc/ca-certificates/update.d/adoptium-cacerts
 
 # Set capabilities when available for add-ons using Pcap4J
 if capsh --print | grep -E 'Current:.+,cap_net_admin,cap_net_raw,.+' >/dev/null; then


### PR DESCRIPTION
* Replace Temurin with OpenJDK from Debian repos which does not crash when using arm64 image on the Raspberry Pi 3
* Switch back to Debian 11 which consumes less memory

Fixes #416
Reverts #422