### PR TITLE
Add script for automatically adding console loggers

### DIFF
--- a/contrib/cont-init.d/20-add-console-loggers
+++ b/contrib/cont-init.d/20-add-console-loggers
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CONFIG_FILE="${OPENHAB_USERDATA}/etc/log4j2.xml"
+OSGI_AREF='<AppenderRef ref="OSGI"/>'
+STDOUT_AREF='<AppenderRef ref="STDOUT"/>'
+
+if [ "$(grep "${STDOUT_AREF}" "${CONFIG_FILE}" | wc -l)" == "1" ]; then
+    echo "Adding console loggers to ${CONFIG_FILE}"
+    sed -i "s#${OSGI_AREF}#${OSGI_AREF}\n\t\t\t${STDOUT_AREF}#g" "${CONFIG_FILE}"
+fi


### PR DESCRIPTION
This script automatically adds the console loggers when they have not yet been configured (see [server mode](https://github.com/openhab/openhab-docker#server-mode)).