### PR TITLE
Make manifests compatible with older Docker versions

### DIFF
--- a/helper-functions
+++ b/helper-functions
@@ -226,7 +226,8 @@ build() {
 	local build_arg_options="--build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg VCS_REF=$(git rev-parse HEAD) --build-arg JAVA_VERSION=$java_version --build-arg OPENHAB_VERSION=$openhab_version"
 	local tags=$(tags $openhab_version $dist)
 	local tag_options=${tags//$(docker_repo)/--tag $(docker_repo)}
-	local build_options="$build_arg_options --platform $(platforms $openhab_version $dist) $tag_options --progress plain $push"
+	local output_options="--output type=image,oci-mediatypes=false,push=$([ "$push" == "--push" ] && echo true || echo false)"
+	local build_options="$build_arg_options --platform $(platforms $openhab_version $dist) $tag_options $output_options --progress plain --provenance=false"
 	local dockerfile_path="./$dist"
 	local build_command="docker buildx build $build_options $dockerfile_path"
 


### PR DESCRIPTION
On old Docker versions pulling an image would fail with "missing signature key". By default buildx creates manifests having the newer OCI media type which is unsupported by older Docker versions.

To inspect the media type in a manifest run: docker manifest inspect openhab/openhab

See:

* https://community.openhab.org/t/containerstation-4-0-0-m3-last-working-build/149063
* https://community.openhab.org/t/error-missing-signature-key-for-oh-4-0-2-docker-image/149154