### PR TITLE
Upgrade GHA dependencies

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,7 +19,7 @@ jobs:
     name: ${{ matrix.tag }}-${{ matrix.distribution }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
@@ -28,7 +28,7 @@ jobs:
           config: ".github/hadolint.yml"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build images
         run: ./build ${{ matrix.tag }} ${{ matrix.distribution }}

--- a/.github/workflows/validate-readme.yml
+++ b/.github/workflows/validate-readme.yml
@@ -15,7 +15,7 @@ jobs:
     name: validate
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Validate README.md
       run: bash -c 'source helper-functions && validate_readme_constraints'


### PR DESCRIPTION
This fixes the following deprecation warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20