### PR TITLE
Change Open Container source annotation to the openHAB distro repository

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
     org.opencontainers.image.url="https://www.openhab.org/" \
     org.opencontainers.image.documentation="https://www.openhab.org/docs/installation/docker.html" \
     org.opencontainers.image.revision=$VCS_REF \
-    org.opencontainers.image.source="https://github.com/openhab/openhab-docker.git" \
+    org.opencontainers.image.source="https://github.com/openhab/openhab-distro.git" \
     org.opencontainers.image.authors="openHAB <info@openhabfoundation.org>"
 
 # https://github.com/hadolint/hadolint/wiki/DL4006

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
     org.opencontainers.image.url="https://www.openhab.org/" \
     org.opencontainers.image.documentation="https://www.openhab.org/docs/installation/docker.html" \
     org.opencontainers.image.revision=$VCS_REF \
-    org.opencontainers.image.source="https://github.com/openhab/openhab-docker.git" \
+    org.opencontainers.image.source="https://github.com/openhab/openhab-distro.git" \
     org.opencontainers.image.authors="openHAB <info@openhabfoundation.org>"
 
 # https://github.com/hadolint/hadolint/wiki/DL4006


### PR DESCRIPTION
This PR changes the [OpenContainer (OCI)](https://opencontainers.org/) image *source* [annotation](https://specs.opencontainers.org/image-spec/annotations/) value to the [openhab-distro](https://github.com/openhab/openhab-distro) repository URL. 

Tools like [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) and [Renovate](https://docs.renovatebot.com/) use this Docker image label when opening PRs for dependency updates. The URL allows these tools to show detailed information about image changes (release notes, changelog entries), making it easier for developers to evaluate the impact of updates.

openHAB uses a separate (this) repository to build Docker images, but neither GitHub releases nor Changelog entries are maintained in this repo. This information is present in the openhab-distro repository instead.

When we change the `org.opencontainers.image.source` label value to the distro package, we enable these tools to fetch the proper information that is being published with new releases,  improving the integration of our images with existing and widely used dependency management tools.