### PR TITLE
Upgrade to Debian 12.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The openHAB Docker images are available in the [openhab/openhab](https://hub.doc
 
 **Distributions:**
 
-* `debian` for Debian 11 "bullseye" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
+* `debian` for Debian 12 "bookworm" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
 * `alpine` for Alpine 3.20 ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/alpine/Dockerfile))
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.9-slim
+FROM debian:12.7-slim
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Regular security support has ended for Debian 11.

See: https://www.debian.org/News/2024/20240814