### PR TITLE
Add openHAB 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,7 @@ The following Docker platforms are supported (automatically determined):
 
 * `linux/amd64`
 * `linux/arm64`
-* `linux/arm/v7`
-
-There is no `linux/arm/v7` Alpine image for openHAB 3 (or newer) because the required openjdk package is unavailable for this platform.
+* `linux/arm/v7` (Debian openHAB 4 (or older), Alpine openHAB 2 (or older))
 
 ## Usage
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -73,7 +73,7 @@ RUN JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name "*jdk*" -type d) && \
 # hadolint ignore=SC2016
 RUN version="$(echo $OPENHAB_VERSION | sed 's/snapshot/SNAPSHOT/g')" && \
     if [ $(echo $version | grep -E '^.+\.(M|RC).+$') ]; then url="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/${version}/openhab-${version}.zip"; \
-    elif [ $(echo $version | grep -E '^4\..+-SNAPSHOT$') ]; then url="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${version}.zip"; \
+    elif [ $(echo $version | grep -E '^5\..+-SNAPSHOT$') ]; then url="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${version}.zip"; \
     else url="https://openhab.jfrog.io/openhab/libs-release/org/openhab/distro/openhab/${version}/openhab-${version}.zip"; fi && \
     wget -nv -O /tmp/openhab.zip "$url" && \
     unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -64,7 +64,7 @@ RUN apk update --no-cache && \
     rm -rf /var/cache/apk/*
 
 # Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-RUN JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name "*jdk*" -type d) && \
+RUN JAVA_HOME=$(find /usr/lib/jvm -mindepth 1 -maxdepth 1 -type d) && \
     sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"
 
 # Install openHAB

--- a/alpine/entrypoint
+++ b/alpine/entrypoint
@@ -4,7 +4,7 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
-export JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name "*jdk*" -type d)
+export JAVA_HOME=$(find /usr/lib/jvm -mindepth 1 -maxdepth 1 -type d)
 
 # Configure Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ]; then

--- a/build
+++ b/build
@@ -50,10 +50,10 @@ resolve_version_tags() {
 }
 
 print_help() {
-	local snapshot_4x=$(grep -E '^4\.[0-9]+\.[0-9]+-snapshot$' <<< $VERSIONS | tail -n 1)
+	local snapshot_5x=$(grep -E '^5\.[0-9]+\.[0-9]+-snapshot$' <<< $VERSIONS | tail -n 1)
 	local milestone_4x=$(grep -E '^4\.[0-9]+\.[0-9]+.(M[0-9]+)$' <<< $VERSIONS | tail -n 1)
-	local stable_3x=$(grep -E '^3\.[0-9]+\.[0-9]+$' <<< $VERSIONS | tail -n 1)
-	local stable_40x=$(grep -E '^4\.0\.[0-9]+$' <<< $VERSIONS | tail -n 1)
+	local stable_42x=$(grep -E '^4\.2\.[0-9]+$' <<< $VERSIONS | tail -n 1)
+	local stable_43x=$(grep -E '^4\.3\.[0-9]+$' <<< $VERSIONS | tail -n 1)
 
 	cat <<-EOI
 Usage: ./build [OPTIONS]
@@ -67,17 +67,17 @@ Log in to the Docker Registry with "docker login" before building and pushing th
 
 Examples:
 
-Build the Debian and Alpine $snapshot_4x images:
+Build the Debian and Alpine $snapshot_5x images:
     ./build
 
-Build the Debian $snapshot_4x images:
+Build the Debian $snapshot_5x images:
     ./build debian
 
 Build the Alpine $milestone_4x images:
     ./build $milestone_4x alpine
 
-Build the $stable_40x and $stable_3x Debian/Alpine images and push them to $(docker_repo):
-    ./build $stable_40x $stable_3x --push
+Build the $stable_43x and $stable_42x Debian/Alpine images and push them to $(docker_repo):
+    ./build $stable_43x $stable_42x --push
 
 Build the latest/snapshot Debian images by resolving the versions ("milestone" can also be resolved):
     ./build latest snapshot debian

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -42,6 +42,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install basepackages. Versions are "pinned" by using a pinned base image.
 # hadolint ignore=DL3008
 RUN apt-get update && \
+    openjdk_package="openjdk-${JAVA_VERSION}-jre-headless" && \
+    apt-get install --no-install-recommends -y --dry-run "$openjdk_package" >/dev/null || openjdk_package="temurin-${JAVA_VERSION}-jre" && \
+    if [ $(echo "$openjdk_package" | grep -E '^temurin-.+$') ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y wget ca-certificates && \
+        wget -nv -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
+        echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
+        apt-get update; \
+    fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         arping \
         ca-certificates \
@@ -53,7 +61,7 @@ RUN apt-get update && \
         locales \
         locales-all \
         netbase \
-        openjdk-${JAVA_VERSION}-jre-headless \
+        "$openjdk_package" \
         procps \
         tini \
         unzip \
@@ -66,7 +74,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Limit JDK crypto policy by default to comply with local laws which may prohibit use of unlimited strength cryptography
-RUN JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name "*jdk*" -type d) && \
+RUN JAVA_HOME=$(find /usr/lib/jvm -mindepth 1 -maxdepth 1 -type d) && \
     sed -i 's/^crypto.policy=unlimited/crypto.policy=limited/' "${JAVA_HOME}/conf/security/java.security"
 
 # Install openHAB

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -75,7 +75,7 @@ RUN JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name "*jdk*" -type d) && \
 # hadolint ignore=SC2016
 RUN version="$(echo $OPENHAB_VERSION | sed 's/snapshot/SNAPSHOT/g')" && \
     if [ $(echo $version | grep -E '^.+\.(M|RC).+$') ]; then url="https://openhab.jfrog.io/openhab/libs-milestone-local/org/openhab/distro/openhab/${version}/openhab-${version}.zip"; \
-    elif [ $(echo $version | grep -E '^4\..+-SNAPSHOT$') ]; then url="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${version}.zip"; \
+    elif [ $(echo $version | grep -E '^5\..+-SNAPSHOT$') ]; then url="https://ci.openhab.org/job/openHAB-Distribution/lastSuccessfulBuild/artifact/distributions/openhab/target/openhab-${version}.zip"; \
     else url="https://openhab.jfrog.io/openhab/libs-release/org/openhab/distro/openhab/${version}/openhab-${version}.zip"; fi && \
     wget -nv -O /tmp/openhab.zip "$url" && \
     unzip -q /tmp/openhab.zip -d "${OPENHAB_HOME}" -x "*.bat" "*.ps1" "*.psm1" && \

--- a/debian/entrypoint
+++ b/debian/entrypoint
@@ -4,7 +4,7 @@ interactive=$(if test -t 0; then echo true; else echo false; fi)
 set -eux -o pipefail ${EXTRA_SHELL_OPTS-}
 IFS=$'\n\t'
 
-export JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name "*jdk*" -type d)
+export JAVA_HOME=$(find /usr/lib/jvm -mindepth 1 -maxdepth 1 -type d)
 
 # Configure Java unlimited strength cryptography
 if [ "${CRYPTO_POLICY}" = "unlimited" ]; then

--- a/helper-functions
+++ b/helper-functions
@@ -36,11 +36,12 @@ platforms() {
 	local version="$1"
 	local base="$2"
 
-	if [ "$base" == "alpine" ]; then
-		# There is no linux/arm/v7 Alpine image for openHAB 3 (or newer) because the required openjdk package is unavailable for this architecture
-		echo "linux/amd64,linux/arm64"
-	else
+	if [[ "$version" =~ ^4.*$ ]] && [ "$base" == "debian" ]; then
 		echo "linux/amd64,linux/arm64,linux/arm/v7"
+	else
+		# There are no linux/arm/v7 images for openHAB 5 (or newer) because this platform is no longer supported.
+		# There are no linux/arm/v7 Alpine images for openHAB 3 (or newer) because the required openjdk package is unavailable for this platform.
+		echo "linux/amd64,linux/arm64"
 	fi
 }
 
@@ -219,8 +220,8 @@ build() {
 
 	local java_version=""
 	case $openhab_version in
-	3.*) java_version="11";;
-	*)   java_version="17";;
+	4.*) java_version="17";;
+	*)   java_version="21";;
 	esac
 
 	local build_arg_options="--build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg VCS_REF=$(git rev-parse HEAD) --build-arg JAVA_VERSION=$java_version --build-arg OPENHAB_VERSION=$openhab_version"


### PR DESCRIPTION
* Use Java 21 with openHAB 5
* Remove linux/arm/v7 support
* Update versions in build help
* Install Temurin when Debian does not have an installation package in its repositories for an OpenJDK version

Related to openhab/openhab-distro#1689