### PR TITLE
Revert workaround for broken `/var/lock` symlink in Alpine 3.21 image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -86,10 +86,6 @@ RUN version="$(echo $OPENHAB_VERSION | sed 's/snapshot/SNAPSHOT/g')" && \
 COPY update ${OPENHAB_HOME}/runtime/bin/update
 RUN chmod +x ${OPENHAB_HOME}/runtime/bin/update
 
-# Workaround for broken /var/lock symlink, see: https://github.com/alpinelinux/docker-alpine/issues/433
-# hadolint ignore=DL3059
-RUN mkdir /run/lock
-
 # Expose volume with configuration and userdata dir
 VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 


### PR DESCRIPTION
Reverts #453 because the issue got fixed in Alpine 3.21.1.