### PR TITLE
Upgrade packages during image creation

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -42,6 +42,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # Install basepackages. Versions are "pinned" by using a pinned base image.
 # hadolint ignore=DL3018
 RUN apk update --no-cache && \
+    apk upgrade --no-cache && \
     apk add --no-cache \
         arping \
         bash \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:12.8-slim
+FROM debian:12-slim
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -42,6 +42,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install basepackages. Versions are "pinned" by using a pinned base image.
 # hadolint ignore=DL3008
 RUN apt-get update && \
+    apt-get upgrade --yes && \
     openjdk_package="openjdk-${JAVA_VERSION}-jre-headless" && \
     apt-get install --no-install-recommends -y --dry-run "$openjdk_package" >/dev/null || openjdk_package="temurin-${JAVA_VERSION}-jre" && \
     if [ $(echo "$openjdk_package" | grep -E '^temurin-.+$') ]; then \


### PR DESCRIPTION
Upgrade from Debian 12.8 to Debian 12.9, released 11-Jan-2025.

I added `apt upgrade` to the Debian script, which should upgrade installed packages. This will basically also upgrade to next 12.x releases once published, as base-files etc. will be upgraded.
WDYT?