### PR TITLE
Upgrade to Debian 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The openHAB Docker images are available in the [openhab/openhab](https://hub.doc
 
 **Distributions:**
 
-* `debian` for Debian 12 "bookworm" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
+* `debian` for Debian 13 "trixie" (default when not specified in tag) ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/debian/Dockerfile))
 * `alpine` for Alpine 3.22 ([Dockerfile](https://github.com/openhab/openhab-docker/blob/main/alpine/Dockerfile))
 
 The Alpine images are substantially smaller than the Debian images but may be less compatible because OpenJDK is used (see [Prerequisites](https://www.openhab.org/docs/installation/#prerequisites) for known disadvantages).

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,5 +1,5 @@
 # Build su-exec used in the Docker image
-FROM debian:12-slim AS su-exec-builder
+FROM debian:13-slim AS su-exec-builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -9,7 +9,7 @@ RUN apt-get update && \
     gcc -Wall "su-exec.c" -o "su-exec"
 
 # Build the openHAB Docker image
-FROM debian:12-slim
+FROM debian:13-slim
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Trixie has been released an will finally upgrade several dependencies.
This will improve the CVE warning in Docker.

This is untested.

I don't know how to obtain a pre-build image from the CI.