### PR TITLE
Use Debian 12 with openHAB 4

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,5 +1,7 @@
 # Build su-exec used in the Docker image
-FROM debian:13-slim AS su-exec-builder
+ARG BASE_IMAGE=debian:13-slim
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE} AS su-exec-builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -9,7 +11,9 @@ RUN apt-get update && \
     gcc -Wall "su-exec.c" -o "su-exec"
 
 # Build the openHAB Docker image
-FROM debian:13-slim
+ARG BASE_IMAGE=debian:13-slim
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -54,7 +58,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY --from=su-exec-builder /su-exec /sbin/su-exec
 
 # Install basepackages. Versions are "pinned" by using a pinned base image.
-# hadolint ignore=DL3008
+# hadolint ignore=DL3008,SC2143
 RUN apt-get update && \
     apt-get upgrade --yes && \
     openjdk_package="openjdk-${JAVA_VERSION}-jre-headless" && \

--- a/helper-functions
+++ b/helper-functions
@@ -27,9 +27,19 @@ bases() {
 	echo "debian alpine"
 }
 
+base_image() {
+	local version="$1"
+	local base="$2"
+
+	if [[ "$version" =~ ^4.*$ ]] && [ "$base" == "debian" ]; then
+		echo "--build-arg BASE_IMAGE=debian:12-slim"
+	fi
+}
+
 docker_repo() {
 	echo "${DOCKER_REPO:=openhab/openhab}"
 }
+
 
 # Supported Docker platforms
 platforms() {
@@ -224,7 +234,7 @@ build() {
 	*)   java_version="21";;
 	esac
 
-	local build_arg_options="--build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg VCS_REF=$(git rev-parse HEAD) --build-arg JAVA_VERSION=$java_version --build-arg OPENHAB_VERSION=$openhab_version"
+	local build_arg_options="$(base_image $openhab_version $dist) --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg VCS_REF=$(git rev-parse HEAD) --build-arg JAVA_VERSION=$java_version --build-arg OPENHAB_VERSION=$openhab_version"
 	local tags=$(tags $openhab_version $dist)
 	local tag_options=${tags//$(docker_repo)/--tag $(docker_repo)}
 	local output_options="--output type=image,oci-mediatypes=false,push=$([ "$push" == "--push" ] && echo true || echo false)"


### PR DESCRIPTION
Debian 13 has no OpenJDK 17 packages and Temurin 17 does not install on Debian 13 as it depends on libasound2 which is missing on armhf.