### PR TITLE
Add startup grace period to healthcheck

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -101,7 +101,7 @@ VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 EXPOSE 8080 8443 8101 5007
 
 # Set healthcheck
-HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:${OPENHAB_HTTP_PORT}/ || exit 1
+HEALTHCHECK --interval=1m --timeout=10s --retries=3 --start-period=20m CMD curl -f http://localhost:${OPENHAB_HTTP_PORT}/ || exit 1
 
 # Set working directory and entrypoint
 WORKDIR ${OPENHAB_HOME}

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -128,7 +128,7 @@ VOLUME ${OPENHAB_CONF} ${OPENHAB_USERDATA} ${OPENHAB_HOME}/addons
 EXPOSE 8080 8443 8101 5007
 
 # Set healthcheck
-HEALTHCHECK --interval=5m --timeout=5s --retries=3 CMD curl -f http://localhost:${OPENHAB_HTTP_PORT}/ || exit 1
+HEALTHCHECK --interval=1m --timeout=10s --retries=3 --start-period=20m CMD curl -f http://localhost:${OPENHAB_HTTP_PORT}/ || exit 1
 
 # Set working directory and entrypoint
 WORKDIR ${OPENHAB_HOME}


### PR DESCRIPTION
Allow slow systems more time to start openHAB before failed healthchecks count toward the unhealthy state. Reduce the interval to one minute so faster systems are reported healthy sooner once the HTTP endpoint responds.

Fixes #490
